### PR TITLE
[FIX] Replace MathUtils with WPILib MathUtil where possible

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -5,6 +5,7 @@ import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 
 import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -27,7 +28,6 @@ import frc.robot.subsystems.drivetrain.SwerveDrive;
 import frc.robot.subsystems.elevator.Elevator;
 import frc.robot.subsystems.elevator.ElevatorConstants;
 import frc.robot.subsystems.elevatorarm.ElevatorArm;
-import frc.robot.util.MathUtils;
 import frc.robot.util.ReefPosition;
 import java.util.function.DoubleSupplier;
 
@@ -52,17 +52,17 @@ public class RobotContainer {
 
   private DoubleSupplier driverForward =
       () ->
-          -MathUtils.deadband(driver.getLeftY(), 0.05)
+          -MathUtil.applyDeadband(driver.getLeftY(), 0.05)
               * (isSlowMode.getAsBoolean()
                   ? 2
                   : DrivetrainConstants.kMaxLinearVelocity.in(MetersPerSecond));
   private DoubleSupplier driverStrafe =
       () ->
-          -MathUtils.deadband(driver.getLeftX(), 0.05)
+          -MathUtil.applyDeadband(driver.getLeftX(), 0.05)
               * (isSlowMode.getAsBoolean()
                   ? 2
                   : DrivetrainConstants.kMaxLinearVelocity.in(MetersPerSecond));
-  private DoubleSupplier driverTurn = () -> -MathUtils.deadband(driver.getRightX(), 0.05) * 5;
+  private DoubleSupplier driverTurn = () -> -MathUtil.applyDeadband(driver.getRightX(), 0.05) * 5;
 
   // robot queued states
   private ReefPosition queuedReefPosition = ReefPosition.NONE;

--- a/src/main/java/frc/robot/util/MathUtils.java
+++ b/src/main/java/frc/robot/util/MathUtils.java
@@ -3,15 +3,8 @@ package frc.robot.util;
 
 public class MathUtils {
 
-  public static boolean epsilonEquals(double a, double b, double epsilon) {
-    return Math.abs(b - a) < epsilon;
-  }
-
+  // TODO: no wpilib alternative but remove if left unused
   public static double squareKeepSign(double x) {
     return Math.signum(x) * x * x;
-  }
-
-  public static double deadband(double x, double deadband) {
-    return Math.abs(x) < deadband ? 0 : x;
   }
 }


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

`MathUtils::deadband`, which is used for driver input, is redundant as WPILib's [`MathUtil::applyDeadband`](https://github.com/wpilibsuite/allwpilib/blob/b60b2b64bd14f842c3a6ff4ee83f4c6be918d8e9/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java#L102) is roughly equivalent in function. The only difference is that `MathUtil::applyDeadband` scales the range from deadband to maximum (1.0) from 0.0 to 1.0 while `MathUtils::deadband` leaves said range untouched. `MathUtils::epsilonEquals` is removed both for not being used anywhere and for being redundant due to WPILib's [`MathUtil::isNear`](https://github.com/wpilibsuite/allwpilib/blob/b60b2b64bd14f842c3a6ff4ee83f4c6be918d8e9/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java#L178), which is identical except for parameter order and even adds a guard against negative epsilon/tolerance values. `MathUtils::squareKeepSign` does not duplicate the functionality of an existing WPILib function, but it is not used anywhere and should be removed if left unused in future commits.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] Someone have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules