### PR TITLE
[FEATURE]: Add method to check whether SwerveDrive is at alignment pose setpoint (and alignment fixes)

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -6,6 +6,9 @@ import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.commands.ProcessorAlign;
+import frc.robot.commands.ReefAlign;
+import frc.robot.commands.StationAlign;
 import frc.robot.util.VirtualSubsystem;
 
 @Logged
@@ -25,6 +28,19 @@ public class Robot extends TimedRobot {
   public Robot() {
     m_robotContainer = new RobotContainer();
     Epilogue.bind(this);
+
+    /*
+     * RobotConstants.kAprilTagFieldLayout takes a significant amount of computing to load,
+     * referencing `RobotConstants.class` here forces the field layout to load instead of stalling
+     * autonomousInit()/teleopInit()
+     */
+    @SuppressWarnings("unused")
+    final var robotConstants = RobotConstants.class;
+
+    // TODO: load robot alliance globally on DS connection to avoid extra lookups
+    ReefAlign.loadReefAlignmentPoses();
+    StationAlign.loadStationAlignmentPoses();
+    ProcessorAlign.loadProcessorAlignmentPoses();
   }
 
   @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -6,9 +6,6 @@ import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import frc.robot.commands.ProcessorAlign;
-import frc.robot.commands.ReefAlign;
-import frc.robot.commands.StationAlign;
 import frc.robot.util.VirtualSubsystem;
 
 @Logged
@@ -47,11 +44,6 @@ public class Robot extends TimedRobot {
 
   @Override
   public void autonomousInit() {
-    // auto init is the first time that alliance is guaranteed to be resolved, according to memory
-    ReefAlign.loadReefAlignmentPoses();
-    StationAlign.loadStationAlignmentPoses();
-    ProcessorAlign.loadProcessorAlignmentPoses();
-
     m_autonomousCommand = m_robotContainer.getAutonomousCommand();
 
     if (m_autonomousCommand != null) {
@@ -67,11 +59,6 @@ public class Robot extends TimedRobot {
 
   @Override
   public void teleopInit() {
-    // alliance is also available here, for testing without needing to enable auto first
-    ReefAlign.loadReefAlignmentPoses();
-    StationAlign.loadStationAlignmentPoses();
-    ProcessorAlign.loadProcessorAlignmentPoses();
-
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -3,11 +3,9 @@ package frc.robot;
 
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
-import static edu.wpi.first.units.Units.Seconds;
 
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -84,24 +82,6 @@ public class RobotContainer {
     RobotModeTriggers.disabled()
         .negate()
         .onTrue(HomingCommands.homeEverything(elevator, algaePivot));
-
-    /*
-        `DriverStation.waitForDsConnection()` takes a timeout,
-        0 represents waiting forever for result (which blocks all robot code),
-        take only a fraction of a robot loop to wait for status, which is fine since the Trigger runs every loop
-    */
-    final var kDSConnectionCheckTimeout = RobotConstants.kRobotLoopPeriod.div(10);
-
-    new Trigger(() -> DriverStation.waitForDsConnection(kDSConnectionCheckTimeout.in(Seconds)))
-        .onTrue(
-            Commands.runOnce(
-                () -> {
-                  // TODO: if this Trigger correctly determines DS connection, also load robot
-                  // alliance to RobotConstants to avoid extra lookups
-                  ReefAlign.loadReefAlignmentPoses();
-                  StationAlign.loadStationAlignmentPoses();
-                  ProcessorAlign.loadProcessorAlignmentPoses();
-                }));
 
     // drive
     drivetrain.setDefaultCommand(drivetrain.teleopDrive(driverForward, driverStrafe, driverTurn));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -3,9 +3,11 @@ package frc.robot;
 
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
+import static edu.wpi.first.units.Units.Seconds;
 
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -82,6 +84,24 @@ public class RobotContainer {
     RobotModeTriggers.disabled()
         .negate()
         .onTrue(HomingCommands.homeEverything(elevator, algaePivot));
+
+    /*
+        `DriverStation.waitForDsConnection()` takes a timeout,
+        0 represents waiting forever for result (which blocks all robot code),
+        take only a fraction of a robot loop to wait for status, which is fine since the Trigger runs every loop
+    */
+    final var kDSConnectionCheckTimeout = RobotConstants.kRobotLoopPeriod.div(10);
+
+    new Trigger(() -> DriverStation.waitForDsConnection(kDSConnectionCheckTimeout.in(Seconds)))
+        .onTrue(
+            Commands.runOnce(
+                () -> {
+                  // TODO: if this Trigger correctly determines DS connection, also load robot
+                  // alliance to RobotConstants to avoid extra lookups
+                  ReefAlign.loadReefAlignmentPoses();
+                  StationAlign.loadStationAlignmentPoses();
+                  ProcessorAlign.loadProcessorAlignmentPoses();
+                }));
 
     // drive
     drivetrain.setDefaultCommand(drivetrain.teleopDrive(driverForward, driverStrafe, driverTurn));

--- a/src/main/java/frc/robot/commands/ProcessorAlign.java
+++ b/src/main/java/frc/robot/commands/ProcessorAlign.java
@@ -28,13 +28,13 @@ public class ProcessorAlign {
   public static final Map<Integer, Pose2d> processorPoses = new HashMap<>();
 
   private static final Distance kProcessorDistance = Inches.of(14);
-  private static final Rotation2d kProcessorAlignmentRotation = Rotation2d.fromDegrees(180);
+  private static final Rotation2d kProcessorAlignmentRotation = Rotation2d.k180deg;
 
   private static final List<Integer> blueProcessorTagIDs = List.of(16);
   private static final List<Integer> redProcessorTagIDs = List.of(3);
 
-  public static final Pose2d kBlueProcessorPose = new Pose2d(5.983, 0.395, new Rotation2d());
-  public static final Pose2d kRedProcessorPose = new Pose2d(11.437, 7.675, new Rotation2d());
+  public static final Pose2d kBlueProcessorPose = new Pose2d(5.983, 0.395, Rotation2d.kZero);
+  public static final Pose2d kRedProcessorPose = new Pose2d(11.437, 7.675, Rotation2d.kZero);
 
   private static final List<AprilTag> blueProcessorTags =
       RobotConstants.kAprilTagFieldLayout.getTags().stream()
@@ -48,8 +48,8 @@ public class ProcessorAlign {
   public static final Distance kAlignmentDeadbandRange = Meters.of(0.75);
 
   /**
-   * This method is run during Robot#autonomousInit() and Robot#teleopInit() to save computations,
-   * only the processor poses are loaded
+   * This method is run when DriverStation connects to save computations mid-match, only the
+   * processor poses are loaded
    */
   public static void loadProcessorAlignmentPoses() {
     List<Integer> processorTagIds = MyAlliance.isRed() ? redProcessorTagIDs : blueProcessorTagIDs;
@@ -120,7 +120,11 @@ public class ProcessorAlign {
   /** Drives to align against the center of the nearest processor, no manual driving */
   public static Command goToNearestAlign(SwerveDrive swerveDrive) {
     return swerveDrive.driveToFieldPose(
-        () -> getNearestAlign(getNearestProcessorID(swerveDrive.getPose())));
+        () -> {
+          final var target = processorPoses.get(getNearestProcessorID(swerveDrive.getPose()));
+          swerveDrive.setAlignmentSetpoint(target);
+          return target;
+        });
   }
 
   /** Maintain translational driving while rotating toward the nearest processor tag */

--- a/src/main/java/frc/robot/commands/ProcessorAlign.java
+++ b/src/main/java/frc/robot/commands/ProcessorAlign.java
@@ -32,17 +32,17 @@ public class ProcessorAlign {
   private static final Transform2d kProcessorAlignTransform =
       new Transform2d(kProcessorDistance, Meter.zero(), kProcessorAlignmentRotation);
 
-  private static final int blueProcessorTagID = 16;
-  private static final int redProcessorTagID = 3;
+  private static final int kBlueProcessorTagID = 16;
+  private static final int kRedProcessorTagID = 3;
 
   // TODO: use units
   public static final Pose2d kBlueProcessorPose = new Pose2d(5.983, 0.395, Rotation2d.kZero);
   public static final Pose2d kRedProcessorPose = new Pose2d(11.437, 7.675, Rotation2d.kZero);
 
-  private static final Pose2d blueProcessorTag =
-      RobotConstants.kAprilTagFieldLayout.getTagPose(blueProcessorTagID).get().toPose2d();
-  private static final Pose2d redProcessorTag =
-      RobotConstants.kAprilTagFieldLayout.getTagPose(redProcessorTagID).get().toPose2d();
+  private static final Pose2d kBlueProcessorTag =
+      RobotConstants.kAprilTagFieldLayout.getTagPose(kBlueProcessorTagID).get().toPose2d();
+  private static final Pose2d kRedProcessorTag =
+      RobotConstants.kAprilTagFieldLayout.getTagPose(kRedProcessorTagID).get().toPose2d();
 
   public static final Distance kAlignmentDeadbandRange = Meters.of(0.75);
 
@@ -51,8 +51,8 @@ public class ProcessorAlign {
    * processor poses are loaded
    */
   public static void loadProcessorAlignmentPoses() {
-    int processorTagId = MyAlliance.isRed() ? redProcessorTagID : blueProcessorTagID;
-    processorPoses.computeIfAbsent(processorTagId, ProcessorAlign::getNearestAlign);
+    processorPoses.computeIfAbsent(kBlueProcessorTagID, ProcessorAlign::getNearestAlign);
+    processorPoses.computeIfAbsent(kRedProcessorTagID, ProcessorAlign::getNearestAlign);
   }
 
   /**
@@ -68,7 +68,7 @@ public class ProcessorAlign {
     if (alliance.isEmpty()) return null;
 
     List<Pose2d> processorTag =
-        List.of(alliance.get().equals(Alliance.Red) ? redProcessorTag : blueProcessorTag);
+        List.of(alliance.get().equals(Alliance.Red) ? kRedProcessorTag : kBlueProcessorTag);
 
     return robotPose.nearest(processorTag);
   }
@@ -116,7 +116,7 @@ public class ProcessorAlign {
   public static Command goToNearestAlign(SwerveDrive swerveDrive) {
     return swerveDrive.driveToFieldPose(
         () -> {
-          final var target = processorPoses.get(getNearestProcessorID(swerveDrive.getPose()));
+          final Pose2d target = processorPoses.get(getNearestProcessorID(swerveDrive.getPose()));
           swerveDrive.setAlignmentSetpoint(target);
           return target;
         });

--- a/src/main/java/frc/robot/commands/ReefAlign.java
+++ b/src/main/java/frc/robot/commands/ReefAlign.java
@@ -39,7 +39,7 @@ public class ReefAlign {
   private static final Distance kReefDistance = Inches.of(14);
   private static final Distance kRightAlignDistance = Inches.of(6.5);
 
-  private static final Rotation2d kReefAlignmentRotation = Rotation2d.fromDegrees(270);
+  private static final Rotation2d kReefAlignmentRotation = Rotation2d.kCW_90deg;
   private static final List<Integer> blueReefTagIDs = List.of(17, 18, 19, 20, 21, 22);
   private static final List<Integer> redReefTagIDs = List.of(6, 7, 8, 9, 10, 11);
   private static final List<AprilTag> blueReefTags =
@@ -51,8 +51,8 @@ public class ReefAlign {
           .filter(tag -> redReefTagIDs.contains(tag.ID))
           .toList();
 
-  public static final Pose2d kRedCenterAlignPos = new Pose2d(13, 4, new Rotation2d());
-  public static final Pose2d kBlueCenterAlignPos = new Pose2d(4.457, 4, new Rotation2d());
+  public static final Pose2d kRedCenterAlignPos = new Pose2d(13, 4, Rotation2d.kZero);
+  public static final Pose2d kBlueCenterAlignPos = new Pose2d(4.457, 4, Rotation2d.kZero);
 
   public static final Distance kMechanismDeadbandThreshold =
       Meters.of(2); // distance to trigger mechanism
@@ -60,8 +60,8 @@ public class ReefAlign {
       Meters.of(5); // distance to trigger alignment
 
   /**
-   * This method is run during Robot#autonomousInit() and Robot#teleopInit() to save computations,
-   * only the poses on the alliance reef are loaded
+   * This method is run when DriverStation connects to save computations mid-match, only the poses
+   * on the alliance reef are loaded
    */
   public static void loadReefAlignmentPoses() {
     final List<Integer> tagIDsToLoad = MyAlliance.isRed() ? redReefTagIDs : blueReefTagIDs;
@@ -189,6 +189,7 @@ public class ReefAlign {
         });
   }
 
+  // TODO: what is this used for?
   public static void alignToReef(SwerveDrive drive, ReefPosition position) {
     drive.driveToFieldPose(
         switch (position) {
@@ -250,6 +251,7 @@ public class ReefAlign {
         () -> getNearestReefPose(swerveDrive.getPose()).getRotation().plus(kReefAlignmentRotation));
   }
 
+  // TODO: what is this used for?
   public static void rotateToNearestReefTag(SwerveDrive swerveDrive, double x, double y) {
     swerveDrive.driveFixedHeading(
         x, y, getNearestReefPose(swerveDrive.getPose()).getRotation().plus(kReefAlignmentRotation));

--- a/src/main/java/frc/robot/commands/ReefAlign.java
+++ b/src/main/java/frc/robot/commands/ReefAlign.java
@@ -169,13 +169,17 @@ public class ReefAlign {
   public static Command alignToReef(
       SwerveDrive swerveDrive, Supplier<ReefPosition> targetReefPosition) {
     return swerveDrive.driveToFieldPose(
-        () ->
-            switch (targetReefPosition.get()) {
-              case ALGAE -> centerAlignPoses.get(getNearestReefID(swerveDrive.getPose()));
-              case LEFT -> leftAlignPoses.get(getNearestReefID(swerveDrive.getPose()));
-              case RIGHT -> rightAlignPoses.get(getNearestReefID(swerveDrive.getPose()));
-              default -> swerveDrive.getPose(); // more or less a no-op
-            });
+        () -> {
+          final var target =
+              switch (targetReefPosition.get()) {
+                case ALGAE -> centerAlignPoses.get(getNearestReefID(swerveDrive.getPose()));
+                case LEFT -> leftAlignPoses.get(getNearestReefID(swerveDrive.getPose()));
+                case RIGHT -> rightAlignPoses.get(getNearestReefID(swerveDrive.getPose()));
+                default -> swerveDrive.getPose(); // more or less a no-op
+              };
+          swerveDrive.setAlignmentSetpoint(target);
+          return target;
+        });
   }
 
   /**

--- a/src/main/java/frc/robot/commands/StationAlign.java
+++ b/src/main/java/frc/robot/commands/StationAlign.java
@@ -27,7 +27,7 @@ public class StationAlign {
   public static final Map<Integer, Pose2d> stationPoses = new HashMap<>();
 
   private static final Distance kStationDistance = Inches.of(14);
-  private static final Rotation2d kStationAlignmentRotation = Rotation2d.fromDegrees(90);
+  private static final Rotation2d kStationAlignmentRotation = Rotation2d.kCCW_90deg;
 
   private static final List<Integer> blueStationTagIDs = List.of(12, 13);
   private static final List<Integer> redStationTagIDs = List.of(1, 2);
@@ -114,7 +114,11 @@ public class StationAlign {
   /** Drives to align against the center of the nearest station, no manual driving */
   public static Command goToNearestCenterAlign(SwerveDrive swerveDrive) {
     return swerveDrive.driveToFieldPose(
-        () -> getNearestCenterAlign(getNearestStationID(swerveDrive.getPose())));
+        () -> {
+          final var target = stationPoses.get(getNearestStationID(swerveDrive.getPose()));
+          swerveDrive.setAlignmentSetpoint(target);
+          return target;
+        });
   }
 
   /** Maintain translational driving while rotating toward the nearest station tag */

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainConstants.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainConstants.java
@@ -1,12 +1,15 @@
 /* (C) Robolancers 2025 */
 package frc.robot.subsystems.drivetrain;
 
+import static edu.wpi.first.units.Units.Centimeters;
+import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 
 import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.LinearVelocity;
@@ -40,4 +43,7 @@ public class DrivetrainConstants {
       MetersPerSecond.of(5.0); // TunerConstants.kSpeedAt12Volts
 
   public static final Time kLoopDt = Seconds.of(0.02);
+
+  public static final Distance kAlignmentSetpointTranslationTolerance = Centimeters.one();
+  public static final Angle kAlignmentSetpointRotationTolerance = Degrees.of(1.5);
 }

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
@@ -1,6 +1,8 @@
 /* (C) Robolancers 2025 */
 package frc.robot.subsystems.drivetrain;
 
+import static edu.wpi.first.units.Units.Degrees;
+import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.Radians;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
@@ -243,7 +245,11 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
 
   @Override
   public boolean atPoseSetpoint() {
-    return getPose().equals(alignmentSetpoint);
+    final var currentPose = getPose();
+    return currentPose.getTranslation().getDistance(alignmentSetpoint.getTranslation())
+            < DrivetrainConstants.kAlignmentSetpointTranslationTolerance.in(Meters)
+        && Math.abs(currentPose.getRotation().minus(alignmentSetpoint.getRotation()).getDegrees())
+            < DrivetrainConstants.kAlignmentSetpointRotationTolerance.in(Degrees);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
@@ -49,6 +49,8 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
           .withDriveRequestType(DriveRequestType.Velocity)
           .withDesaturateWheelSpeeds(true);
 
+  private Pose2d alignmentSetpoint = Pose2d.kZero;
+
   public DrivetrainReal(
       SwerveDrivetrainConstants drivetrainConstants, SwerveModuleConstants<?, ?, ?>... modules) {
     // create CTRE Swervedrivetrain
@@ -250,6 +252,16 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
                   .withTargetDirection(rotation.get())
                   .withForwardPerspective(ForwardPerspectiveValue.BlueAlliance));
         });
+  }
+
+  @Override
+  public void setAlignmentSetpoint(Pose2d setpoint) {
+    alignmentSetpoint = setpoint;
+  }
+
+  @Override
+  public boolean atPoseSetpoint() {
+    return getPose().equals(alignmentSetpoint);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
@@ -38,6 +38,7 @@ import org.ironmaple.simulation.drivesims.configs.DriveTrainSimulationConfig;
 public class DrivetrainSim implements SwerveDrive {
   private final SelfControlledSwerveDriveSimulationWrapper simulatedDrive;
   private final Field2d field2d;
+  private Pose2d alignmentSetpoint = Pose2d.kZero;
   final DriveTrainSimulationConfig simConfig;
   PIDController headingController;
 
@@ -231,6 +232,16 @@ public class DrivetrainSim implements SwerveDrive {
   @Override
   public void resetPose(Pose2d pose) {
     simulatedDrive.resetOdometry(pose);
+  }
+
+  @Override
+  public void setAlignmentSetpoint(Pose2d setpoint) {
+    alignmentSetpoint = setpoint;
+  }
+
+  @Override
+  public boolean atPoseSetpoint() {
+    return getPose().equals(alignmentSetpoint);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
@@ -1,7 +1,9 @@
 /* (C) Robolancers 2025 */
 package frc.robot.subsystems.drivetrain;
 
+import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.Pounds;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
@@ -229,7 +231,11 @@ public class DrivetrainSim implements SwerveDrive {
 
   @Override
   public boolean atPoseSetpoint() {
-    return getPose().equals(alignmentSetpoint);
+    final var currentPose = getPose();
+    return currentPose.getTranslation().getDistance(alignmentSetpoint.getTranslation())
+            < DrivetrainConstants.kAlignmentSetpointTranslationTolerance.in(Meters)
+        && Math.abs(currentPose.getRotation().minus(alignmentSetpoint.getRotation()).getDegrees())
+            < DrivetrainConstants.kAlignmentSetpointRotationTolerance.in(Degrees);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
@@ -109,15 +109,15 @@ public interface SwerveDrive extends Subsystem {
     return MyAlliance.isRed() ? rotation.plus(Rotation2d.k180deg) : rotation;
   }
 
-  default boolean atPoseSetpoint() {
-    /*
-    * TODO: should there be additional SwerveDrive state to store
-      the alignment setpoint so that atPoseSetpoint() checks against that setpoint instead?
-    */
-    return xPoseController.atSetpoint()
-        && yPoseController.atSetpoint()
-        && thetaController.atSetpoint();
-  }
+  void setAlignmentSetpoint(Pose2d setpoint);
+
+  /**
+   * Checks whether the translation components and rotation are within 1e-9, the WPILib default
+   * tolerance for equality
+   *
+   * @return whether the SwerveDrive is at the target alignment pose
+   */
+  boolean atPoseSetpoint();
 
   Command teleopDrive(
       DoubleSupplier translationX, DoubleSupplier translationY, DoubleSupplier rotation);

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
@@ -109,6 +109,16 @@ public interface SwerveDrive extends Subsystem {
     return MyAlliance.isRed() ? rotation.plus(Rotation2d.k180deg) : rotation;
   }
 
+  default boolean atPoseSetpoint() {
+    /*
+    * TODO: should there be additional SwerveDrive state to store
+      the alignment setpoint so that atPoseSetpoint() checks against that setpoint instead?
+    */
+    return xPoseController.atSetpoint()
+        && yPoseController.atSetpoint()
+        && thetaController.atSetpoint();
+  }
+
   Command teleopDrive(
       DoubleSupplier translationX, DoubleSupplier translationY, DoubleSupplier rotation);
 

--- a/src/main/java/frc/robot/util/AprilTagUtil.java
+++ b/src/main/java/frc/robot/util/AprilTagUtil.java
@@ -1,0 +1,14 @@
+/* (C) Robolancers 2025 */
+package frc.robot.util;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import frc.robot.RobotConstants;
+import java.util.List;
+
+public class AprilTagUtil {
+  public static List<Pose2d> tagIDsToPoses(List<Integer> ids) {
+    return ids.stream()
+        .map(id -> RobotConstants.kAprilTagFieldLayout.getTagPose(id).get().toPose2d())
+        .toList();
+  }
+}


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

To facilitate alignment to the reef, coral station, and processor, this pull request creates a new `SwerveDrive` method that checks the `xPoseController`, `yPoseController`, and `thetaController`. Pending discussion about storing `SwerveDrive`'s current target alignment pose to check against.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] In progress (fix or feature that isn't completed / ignore checklist if this is marked) 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] Someone have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules