### PR TITLE
[FIX] Re-oriented Robot

### DIFF
--- a/AdvantageScopeAssets/Robot_321/config.json
+++ b/AdvantageScopeAssets/Robot_321/config.json
@@ -2,43 +2,43 @@
     "name": "321Robot",
     "rotations": [
         {"axis" : "x", "degrees": 90},
-        {"axis" : "z", "degrees": 180},
+        {"axis" : "z", "degrees": 270},
         {"axis" : "y", "degrees": 0}
     ],
-    "position": [0.216, 0.156, -0.105],
+    "position": [-0.156, 0.216, -0.105],
     "cameras": [],
     "components": [
         {
             "zeroedRotations": [
                 {"axis" : "x", "degrees": 90},
-                {"axis" : "z", "degrees": 180},
+                {"axis" : "z", "degrees": 270},
                 {"axis" : "y", "degrees": 0}
             ],
-            "zeroedPosition": [0.215, 0.156, -0.110]
+            "zeroedPosition": [-0.156, 0.215, -0.110]
         },
         {
             "zeroedRotations": [
                 {"axis" : "x", "degrees": 90},
-                {"axis" : "z", "degrees": 180},
+                {"axis" : "z", "degrees": 270},
                 {"axis" : "y", "degrees": 0}
             ],
-            "zeroedPosition": [0.215, 0.156, -0.104]
+            "zeroedPosition": [-0.156, 0.215, -0.104]
         },
         {
             "zeroedRotations": [
                 {"axis" : "x", "degrees": 90},
-                {"axis" : "z", "degrees": 180},
+                {"axis" : "z", "degrees": 270},
                 {"axis" : "y", "degrees": 0}
             ],
-            "zeroedPosition": [0.31, 0.23, -0.97]
+            "zeroedPosition": [-0.23, 0.31, -0.97]
         },
         {
             "zeroedRotations": [
                 {"axis" : "x", "degrees": 90},
-                {"axis" : "z", "degrees": 180},
+                {"axis" : "z", "degrees": 270},
                 {"axis" : "y", "degrees": 0}
             ],
-            "zeroedPosition": [-0.1127, 0.156, -0.32]
+            "zeroedPosition": [-0.156, -0.1127, -0.32]
         }
 
     ]

--- a/src/main/java/frc/robot/commands/ProcessorAlign.java
+++ b/src/main/java/frc/robot/commands/ProcessorAlign.java
@@ -28,7 +28,7 @@ public class ProcessorAlign {
   public static final Map<Integer, Pose2d> processorPoses = new HashMap<>();
 
   private static final Distance kProcessorDistance = Inches.of(14);
-  private static final Rotation2d kProcessorAlignmentRotation = Rotation2d.fromDegrees(180);
+  private static final Rotation2d kProcessorAlignmentRotation = Rotation2d.fromDegrees(90);
 
   private static final List<Integer> blueProcessorTagIDs = List.of(16);
   private static final List<Integer> redProcessorTagIDs = List.of(3);

--- a/src/main/java/frc/robot/commands/ReefAlign.java
+++ b/src/main/java/frc/robot/commands/ReefAlign.java
@@ -39,7 +39,7 @@ public class ReefAlign {
   private static final Distance kReefDistance = Inches.of(14);
   private static final Distance kRightAlignDistance = Inches.of(6.5);
 
-  private static final Rotation2d kReefAlignmentRotation = Rotation2d.fromDegrees(270);
+  private static final Rotation2d kReefAlignmentRotation = Rotation2d.fromDegrees(180);
   private static final List<Integer> blueReefTagIDs = List.of(17, 18, 19, 20, 21, 22);
   private static final List<Integer> redReefTagIDs = List.of(6, 7, 8, 9, 10, 11);
   private static final List<AprilTag> blueReefTags =

--- a/src/main/java/frc/robot/commands/StationAlign.java
+++ b/src/main/java/frc/robot/commands/StationAlign.java
@@ -27,7 +27,7 @@ public class StationAlign {
   public static final Map<Integer, Pose2d> stationPoses = new HashMap<>();
 
   private static final Distance kStationDistance = Inches.of(14);
-  private static final Rotation2d kStationAlignmentRotation = Rotation2d.fromDegrees(90);
+  private static final Rotation2d kStationAlignmentRotation = Rotation2d.fromDegrees(0);
 
   private static final List<Integer> blueStationTagIDs = List.of(12, 13);
   private static final List<Integer> redStationTagIDs = List.of(1, 2);

--- a/src/main/java/frc/robot/subsystems/SuperstructureVisualizer.java
+++ b/src/main/java/frc/robot/subsystems/SuperstructureVisualizer.java
@@ -106,7 +106,7 @@ public class SuperstructureVisualizer extends VirtualSubsystem {
     this.shoulderPose =
         new Pose3d(
             VisualizerConstants.armRoot3d.plus(new Translation3d(0, 0, startHeightToSetpoint)),
-            new Rotation3d(Radians.convertFrom(-arm.getAngle() - 90, Degrees), 0, 0));
+            new Rotation3d(0, Radians.convertFrom(-arm.getAngle() - 90, Degrees), 0));
 
     this.elbowPose =
         shoulderPose.transformBy(
@@ -117,7 +117,7 @@ public class SuperstructureVisualizer extends VirtualSubsystem {
     this.algaeIntakePose =
         new Pose3d(
             VisualizerConstants.algaeRoot3d,
-            new Rotation3d(0, algaePivotSetpoint.get().in(Radians), 0));
+            new Rotation3d(-algaePivotSetpoint.get().in(Radians), 0, 0));
   }
 
   @Logged(name = "ElevatorFirstStage")

--- a/src/main/java/frc/robot/subsystems/VisualizerConstants.java
+++ b/src/main/java/frc/robot/subsystems/VisualizerConstants.java
@@ -29,9 +29,8 @@ public class VisualizerConstants {
               ElevatorConstants.kElevatorMinimumHeight.in(Meters)));
 
   // arm shoulder joint in 3d
-  public static final Translation3d armRoot3d =
-      new Translation3d(-0.31 + 0.225, -0.23 + 0.156, 0.97 + (-0.104));
+  public static final Translation3d armRoot3d = new Translation3d(0.074, -0.085, 0.866);
 
   // rotating joint of the algae intake
-  public static final Translation3d algaeRoot3d = new Translation3d(0.3287, 0, 0.2181606);
+  public static final Translation3d algaeRoot3d = new Translation3d(0, 0.3287, 0.2181606);
 }


### PR DESCRIPTION


# Description

So apparently, the robot's algae intake isn't forward; the side that we score on is forward... Weird, right? Well, to resolve any possible communication issues later on, this PR changes all rotations to be based on the scoring side being forward, which means changing simulation visualizer constants and alignment angles. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] In progress (fix or feature that isn't completed / ignore checklist if this is marked) 

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] Someone have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules