### PR TITLE
[FIX] Vision STDDEVs Changes

### DIFF
--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -6,10 +6,14 @@ import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Milliseconds;
 import static edu.wpi.first.units.Units.Seconds;
 
+import edu.wpi.first.math.geometry.Rectangle2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.Time;
+import frc.robot.RobotConstants;
 import org.photonvision.simulation.SimCameraProperties;
 
 public class VisionConstants {
@@ -131,4 +135,16 @@ public class VisionConstants {
     kFrontSwerveCameraConfig,
     kBackLeftSwerveCameraConfig
   };
+
+  // camera data filtering
+  public static final Distance kAllowedFieldDistance =
+      Meters.of(2.5); // allow field estimates 2.5 meters outside field
+  public static final Rectangle2d kAllowedFieldArea =
+      new Rectangle2d(
+          new Translation2d(-kAllowedFieldDistance.in(Meters), -kAllowedFieldDistance.in(Meters)),
+          new Translation2d(
+              RobotConstants.kAprilTagFieldLayout.getFieldLength()
+                  + kAllowedFieldDistance.in(Meters),
+              RobotConstants.kAprilTagFieldLayout.getFieldWidth()
+                  + kAllowedFieldDistance.in(Meters)));
 }


### PR DESCRIPTION
# Description

Rationale behind choice: The only times we want to more or less accept vision estimates are if they have a low distance value or if they have a high amount of targets used. This PR encourages this. 

Changed vision standard deviation calculations in the following way: 
- removed reliance on latency and alternate distance
- raised avg distance to 3rd power to discourage large distances
- raised targets size to 3rd power to encourage multiple targets

Result: Pose is generally more stable, any unnecessary jumps from bad vision data are not as big and are quickly patched up by other vision data. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] In progress (fix or feature that isn't completed / ignore checklist if this is marked) 

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] Someone have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules