### PR TITLE
[FEATURE] FOM Pose Estimator 

### DIFF
--- a/simgui-ds.json
+++ b/simgui-ds.json
@@ -4,6 +4,11 @@
       "visible": true
     }
   },
+  "System Joysticks": {
+    "window": {
+      "enabled": false
+    }
+  },
   "keyboardJoysticks": [
     {
       "axisConfig": [

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -58,11 +58,7 @@ public class RobotContainer {
           (drivetrain instanceof DrivetrainSim)
               ? ((DrivetrainSim) drivetrain)::getActualPose
               : drivetrain::getPose,
-          visionEst ->
-              drivetrain.addVisionMeasurement(
-                  visionEst.estimate().estimatedPose.toPose2d(),
-                  visionEst.estimate().timestampSeconds,
-                  visionEst.stdDevs()),
+          visionEst -> drivetrain.addVisionMeasurementFOM(visionEst),
           reefVisionEst ->
               drivetrain.addReefVisionMeasurement(
                   reefVisionEst.estimate().estimatedPose.toPose2d(),

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainConstants.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainConstants.java
@@ -6,14 +6,12 @@ import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
-import static edu.wpi.first.units.Units.Seconds;
 
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.LinearVelocity;
-import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.wpilibj.RobotBase;
 
 @Logged
@@ -43,8 +41,8 @@ public class DrivetrainConstants {
   public static final LinearVelocity kMaxLinearVelocity =
       MetersPerSecond.of(5.0); // TunerConstants.kSpeedAt12Volts
 
-  public static final Time kLoopDt = Seconds.of(0.02);
-
   public static final Distance kAlignmentSetpointTranslationTolerance = Meters.of(0.015);
   public static final Angle kAlignmentSetpointRotationTolerance = Degrees.of(2.0);
+
+  public static final double kTranslationStdDevCoeff = 1;
 }

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
@@ -36,6 +36,7 @@ import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.RobotConstants;
 import frc.robot.util.MyAlliance;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
@@ -74,6 +75,8 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
 
   private Pose2d alignmentSetpoint = Pose2d.kZero;
 
+  private RobotPoseEstimator FOMPoseEstimator;
+
   public DrivetrainReal(
       SwerveDrivetrainConstants drivetrainConstants, SwerveModuleConstants<?, ?, ?>... modules) {
     // create CTRE Swervedrivetrain
@@ -85,6 +88,8 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
     this.reefPoseEstimator =
         new SwerveDrivePoseEstimator(
             getKinematics(), getHeading(), getModulePositions(), getPose());
+
+    this.FOMPoseEstimator = new RobotPoseEstimator(getKinematics(), getMeasuredModuleStates());
 
     SmartDashboard.putData("Drivetrain Pose Field", poseField);
   }
@@ -99,7 +104,7 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
                   translationX.getAsDouble(),
                   translationY.getAsDouble(),
                   rotation.getAsDouble(),
-                  DrivetrainConstants.kLoopDt.in(Seconds));
+                  RobotConstants.kRobotLoopPeriod.in(Seconds));
 
           // x braking
           // if(Math.abs(newTranslationX) < DriveConstants.kDriveDeadband &&
@@ -134,7 +139,7 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
                   translationX.getAsDouble(),
                   translationY.getAsDouble(),
                   0,
-                  DrivetrainConstants.kLoopDt.in(Seconds));
+                  RobotConstants.kRobotLoopPeriod.in(Seconds));
 
           setControl(
               fieldCentricFacingAngleRequest
@@ -156,7 +161,7 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
                   translationX.getAsDouble(),
                   translationY.getAsDouble(),
                   rotation.getAsDouble(),
-                  DrivetrainConstants.kLoopDt.in(Seconds));
+                  RobotConstants.kRobotLoopPeriod.in(Seconds));
 
           setControl(
               fieldCentricRequest
@@ -218,7 +223,7 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
                                   getPose().getRotation().getRadians(),
                                   pose.get().getRotation().getRadians())
                               * DrivetrainConstants.kMaxAngularVelocity.in(RadiansPerSecond),
-                          DrivetrainConstants.kLoopDt.in(Seconds));
+                          RobotConstants.kRobotLoopPeriod.in(Seconds));
 
                   driveRobotCentric(
                       targetSpeeds.vxMetersPerSecond,
@@ -236,7 +241,7 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
             yPoseController.calculate(getPose().getY(), pose.getY()),
             thetaController.calculate(
                 getPose().getRotation().getRadians(), pose.getRotation().getRadians()),
-            DrivetrainConstants.kLoopDt.in(Seconds));
+            RobotConstants.kRobotLoopPeriod.in(Seconds));
 
     if (atPoseSetpoint()) targetSpeeds = new ChassisSpeeds();
 
@@ -261,7 +266,7 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
   public void driveFixedHeading(double translationX, double translationY, Rotation2d rotation) {
     var speeds =
         ChassisSpeeds.discretize(
-            translationX, translationY, 0, DrivetrainConstants.kLoopDt.in(Seconds));
+            translationX, translationY, 0, RobotConstants.kRobotLoopPeriod.in(Seconds));
 
     setControl(
         fieldCentricFacingAngleRequest
@@ -353,6 +358,10 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
 
   @Override
   public void periodic() {
+    FOMPoseEstimator.update(getMeasuredModuleStates());
+    super.setStateStdDevs(FOMPoseEstimator.calculateRobotStdDev());
+    SmartDashboard.putBoolean("collision detected", FOMPoseEstimator.detectCollision());
+
     reefPoseEstimator.update(getHeading(), getModulePositions());
 
     if (DriverStation.isDisabled()) {

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
@@ -37,6 +37,7 @@ import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.RobotConstants;
+import frc.robot.subsystems.vision.VisionEstimate;
 import frc.robot.util.MyAlliance;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
@@ -353,6 +354,9 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
     super.addVisionMeasurement(
         visionRobotPose, Utils.fpgaToCurrentTime(timeStampSeconds), standardDeviations);
   }
+
+  @Override
+  public void addVisionMeasurementFOM(VisionEstimate visionEstimate) {}
 
   @NotLogged private Alliance lastAlliance;
 

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
@@ -8,7 +8,9 @@ import static edu.wpi.first.units.Units.Pounds;
 
 import com.pathplanner.lib.util.DriveFeedforwards;
 import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.epilogue.NotLogged;
 import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -24,6 +26,7 @@ import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.commands.ReefAlign;
+import frc.robot.subsystems.vision.VisionEstimate;
 import frc.robot.util.SelfControlledSwerveDriveSimulationWrapper;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
@@ -44,6 +47,11 @@ public class DrivetrainSim implements SwerveDrive {
   PIDController headingController;
 
   private final SwerveDrivePoseEstimator reefPoseEstimator;
+  private final RobotPoseEstimator fomPoseEstimator;
+  private Pose2d fomPose = Pose2d.kZero;
+  private Pose2d visionPose = Pose2d.kZero;
+
+  @NotLogged private Matrix<N3, N1> visionStdDev = VecBuilder.fill(0, 0, 0);
 
   public DrivetrainSim() {
     this.simConfig =
@@ -85,6 +93,9 @@ public class DrivetrainSim implements SwerveDrive {
     this.reefPoseEstimator =
         new SwerveDrivePoseEstimator(
             simulatedDrive.getKinematics(), getHeading(), getModulePositions(), getPose());
+
+    this.fomPoseEstimator =
+        new RobotPoseEstimator(simulatedDrive.getKinematics(), getMeasuredModuleStates());
 
     configureAutoBuilder();
     configurePoseControllers();
@@ -314,16 +325,29 @@ public class DrivetrainSim implements SwerveDrive {
   }
 
   @Override
+  public void addVisionMeasurementFOM(VisionEstimate visionEstimate) {
+    this.visionPose = visionEstimate.estimate().estimatedPose.toPose2d();
+    this.visionStdDev = visionEstimate.stdDevs();
+  }
+
+  @Override
   public void periodic() {
     // update simulated drive and arena
     SimulatedArena.getInstance().simulationPeriodic();
     simulatedDrive.periodic();
 
     reefPoseEstimator.update(getHeading(), getModulePositions());
+    fomPoseEstimator.update(getMeasuredModuleStates());
+    fomPose = fomPoseEstimator.getWeightedRobotPose(getPose(), visionPose, visionStdDev);
 
     // send simulation data to dashboard for testing
     field2d.setRobotPose(simulatedDrive.getActualPoseInSimulationWorld());
     field2d.getObject("odometry").setPose(getPose());
+  }
+
+  @Logged(name = "FOMPose")
+  public Pose2d getFomPose() {
+    return fomPose;
   }
 
   @Logged(name = "RobotLeftAligned")

--- a/src/main/java/frc/robot/subsystems/drivetrain/RobotPoseEstimator.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/RobotPoseEstimator.java
@@ -1,0 +1,157 @@
+/* (C) Robolancers 2025 */
+package frc.robot.subsystems.drivetrain;
+
+import static edu.wpi.first.units.Units.Seconds;
+
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.wpilibj.BuiltInAccelerometer;
+import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.simulation.BuiltInAccelerometerSim;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import frc.robot.RobotConstants;
+import java.util.HashMap;
+
+/*
+ * PoseEstimator class that uses 1690 FOM system. Assumes standard deviation and FOM to be the conceptionally the same.
+ * Alternative way to use this: use calculateRobotStdDev() in DrivetrainReal to update robotStdDev
+ */
+public class RobotPoseEstimator {
+  private SwerveDriveKinematics kinematics;
+  private SwerveModuleState[] moduleStates;
+  private BuiltInAccelerometer accelerometer = new BuiltInAccelerometer();
+  ;
+  private BuiltInAccelerometerSim accelerometerSim = new BuiltInAccelerometerSim(accelerometer);
+  ;
+
+  // variables
+  private double lastAccelX = 0;
+  private double lastAccelY = 0;
+  private double kCollisionThreshold = 2;
+
+  // key - position, value - FOM
+  private HashMap<Double, Double> xFOMPose = new HashMap<Double, Double>();
+  private HashMap<Double, Double> yFOMPose = new HashMap<Double, Double>();
+
+  public RobotPoseEstimator(SwerveDriveKinematics kinematics, SwerveModuleState[] modulesStates) {
+    this.kinematics = kinematics;
+    this.moduleStates = modulesStates;
+  }
+
+  public Matrix<N3, N1> calculateRobotStdDev() {
+    // subtract 1 so the values are [0, infinity],
+    double stdDevs = calculateSkiddingRatio() - 1;
+
+    double translationStdDev = stdDevs * DrivetrainConstants.kTranslationStdDevCoeff;
+
+    return VecBuilder.fill(translationStdDev, translationStdDev, 0);
+  }
+
+  // returns FOM of robot pose [1, INFINITY]
+  public double calculateSkiddingRatio() {
+    // find current angular velocity
+    final double angularVelocityOmegaMeasured =
+        kinematics.toChassisSpeeds(moduleStates).omegaRadiansPerSecond;
+
+    // chassis rotational speeds
+    final SwerveModuleState[] swerveStatesRotationalPart =
+        kinematics.toSwerveModuleStates(new ChassisSpeeds(0, 0, angularVelocityOmegaMeasured));
+
+    // chassis translational speeds
+    final double[] swerveStatesTranslationalPartMagnitudes = new double[moduleStates.length];
+
+    // for every module, convert swerve states to velocity vectors
+    for (int i = 0; i < moduleStates.length; i++) {
+      final Translation2d
+          swerveStateMeasuredAsVector =
+              convertSwerveStateToVelocityVector(moduleStates[i]), // total chassis velocity
+          swerveStatesRotationalPartAsVector = // rotational velocity
+          convertSwerveStateToVelocityVector(swerveStatesRotationalPart[i]),
+          swerveStatesTranslationalPartAsVector = // translational velocity
+          swerveStateMeasuredAsVector.minus(swerveStatesRotationalPartAsVector);
+      swerveStatesTranslationalPartMagnitudes[i] = swerveStatesTranslationalPartAsVector.getNorm();
+    }
+
+    // find maximum & minimum translation
+    double maximumTranslationalSpeed = 0, minimumTranslationalSpeed = Double.POSITIVE_INFINITY;
+    for (double translationalSpeed : swerveStatesTranslationalPartMagnitudes) {
+      maximumTranslationalSpeed = Math.max(maximumTranslationalSpeed, translationalSpeed);
+      minimumTranslationalSpeed = Math.min(minimumTranslationalSpeed, translationalSpeed);
+    }
+
+    // skid ratio
+    SmartDashboard.putNumber("skid ratio", maximumTranslationalSpeed / minimumTranslationalSpeed);
+    return maximumTranslationalSpeed / minimumTranslationalSpeed;
+  }
+
+  private static Translation2d convertSwerveStateToVelocityVector(
+      SwerveModuleState swerveModuleState) {
+    return new Translation2d(swerveModuleState.speedMetersPerSecond, swerveModuleState.angle);
+  }
+
+  // TODO accelatormator doesnt give data? fix this
+  public boolean detectCollision() {
+    // find accelermator spike x
+    double currentAccelX = RobotBase.isReal() ? accelerometer.getX() : accelerometerSim.getX();
+    double jerkX = (currentAccelX - lastAccelX) / RobotConstants.kRobotLoopPeriod.in(Seconds);
+    lastAccelX = currentAccelX;
+
+    // find accelermator spike y
+    double currentAccelY = RobotBase.isReal() ? accelerometer.getY() : accelerometerSim.getY();
+    double jerkY = (currentAccelY - lastAccelY) / RobotConstants.kRobotLoopPeriod.in(Seconds);
+    lastAccelY = currentAccelY;
+
+    // if we get a spike >2 G then we have a collision
+    return Math.abs(jerkX) > kCollisionThreshold && Math.abs(jerkY) > kCollisionThreshold;
+  }
+
+  // called periodically to update pose estimator
+  public void update(SwerveModuleState[] moduleStates) {
+    this.moduleStates = moduleStates;
+  }
+
+  public Pose2d getWeightedRobotPose(
+      Pose2d robotPose, Pose2d visionPose, Matrix<N3, N1> visionStdDev) {
+    // if we are in a collision, ignore robot pose or increase FOM
+    double robotFOM = detectCollision() ? Double.POSITIVE_INFINITY : calculateSkiddingRatio();
+
+    // TODO calculate this based on how jittery the response is
+    double visionFOM = visionStdDev.get(0, 0) + 1;
+
+    // fill maps w/ fom and poses
+    xFOMPose.put(robotPose.getX(), robotFOM);
+    xFOMPose.put(visionPose.getX(), visionFOM);
+    yFOMPose.put(robotPose.getY(), robotFOM);
+    yFOMPose.put(visionPose.getY(), visionFOM);
+
+    // calculate weighted avg of translational pose
+    double weightedPoseX = calculateWeightedAverage(xFOMPose);
+    double weightedPoseY = calculateWeightedAverage(yFOMPose);
+
+    // clear maps for next iteration
+    xFOMPose.clear();
+    yFOMPose.clear();
+
+    return new Pose2d(weightedPoseX, weightedPoseY, robotPose.getRotation());
+  }
+
+  // calculate weighted average based on 1690's pose merging
+  private double calculateWeightedAverage(HashMap<Double, Double> map) {
+    double num = 0;
+    double denom = 0;
+
+    for (HashMap.Entry<Double, Double> entry : map.entrySet()) {
+      num += (1 / Math.pow(entry.getValue(), 2)) * entry.getKey();
+      denom += (1 / Math.pow(entry.getValue(), 2));
+    }
+
+    return num / denom;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
@@ -21,6 +21,7 @@ import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Subsystem;
+import frc.robot.subsystems.vision.VisionEstimate;
 import frc.robot.util.MyAlliance;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
@@ -214,4 +215,6 @@ public interface SwerveDrive extends Subsystem {
    */
   void addReefVisionMeasurement(
       Pose2d visionRobotPose, double timeStampSeconds, Matrix<N3, N1> standardDeviations);
+
+  void addVisionMeasurementFOM(VisionEstimate visionEstimate);
 }


### PR DESCRIPTION
# Description

Uses 1690 Orbit's pose calculations to create a trust-based / FOM pose estimator. As of right now:

- standard deviation / FOM calculations are incorrect and need to be tuned and made. 
- Collision detection has not worked in simulation since I couldn't get the accelerometer to output any data. 
- Skid detection math does work; expected values are between 1 - 4

`DrivetrainReal` uses the estimator for `setStateStdDevs()` and logs the collision detection. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] In progress (fix or feature that isn't completed / ignore checklist if this is marked) 

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] Someone have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules