### PR TITLE
[FIX] New Alignment Routine for Elevator Wobble

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -459,29 +459,7 @@ public class RobotContainer {
                             && isCoralSetpoint.getAsBoolean()) // and outtake coral
                 // .until(() -> !coralSuperstructure.hasCoral()) // until we don't have coral
                 .withTimeout(0.5) // timeout at 1 second
-                .andThen(
-                    // move arm up and go back down (only if we're already at the scoring setpoint
-                    // state)
-                    coralSuperstructure
-                        .goToSetpointPID(
-                            () -> CoralScorerSetpoint.NEUTRAL.getElevatorHeight(),
-                            () -> CoralScorerSetpoint.PREALIGN.getArmAngle())
-                        .until(
-                            () ->
-                                coralSuperstructure
-                                    .getElevator()
-                                    .atHeight(CoralScorerSetpoint.NEUTRAL.getElevatorHeight()))
-                        .onlyIf(
-                            () ->
-                                !coralSuperstructure
-                                    .getElevator()
-                                    .atHeight(
-                                        CoralScorerSetpoint.NEUTRAL
-                                            .getElevatorHeight()))) // and then resume default
-                // command
-                // only if we're at the target state and are ready to score
-
-                .withInterruptBehavior(InterruptionBehavior.kCancelIncoming));
+            );
 
     // --- DEALGAEFYING ---
     driver

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -12,7 +12,6 @@ import edu.wpi.first.wpilibj.GenericHID.RumbleType;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.simulation.AddressableLEDSim;
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Command.InterruptionBehavior;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
@@ -406,12 +405,7 @@ public class RobotContainer {
                             () ->
                                 !coralSuperstructure
                                     .getElevator()
-                                    .atHeight(
-                                        CoralScorerSetpoint.NEUTRAL
-                                            .getElevatorHeight()))) // and then resume default
-                // command
-                // only if we're at the target state and are ready to score
-                .withInterruptBehavior(InterruptionBehavior.kCancelIncoming));
+                                    .atHeight(CoralScorerSetpoint.NEUTRAL.getElevatorHeight()))));
 
     // --- CORAL MANUAL CONTROLS ---
     driver

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -287,26 +287,27 @@ public class RobotContainer {
                         // when we get far away, repeat the command
                         .repeatedly()
                         .alongWith(
-                            coralSuperstructure.goToSetpointProfiled(
-                                () ->
-                                    Meters.of(
-                                        Math.min(
-                                            queuedSetpoint.getElevatorHeight().in(Meters),
-                                            CoralScorerSetpoint.PREALIGN
-                                                .getElevatorHeight()
-                                                .in(Meters))),
-                                () -> CoralScorerSetpoint.PREALIGN.getArmAngle()))
-                        .until(
-                            () ->
-                                ReefAlign.isWithinReefRange(
-                                    drivetrain, ReefAlign.kReefAlignmentThreshold))
-
+                            coralSuperstructure
+                                .goToSetpointProfiled(
+                                    () ->
+                                        Meters.of(
+                                            Math.min(
+                                                queuedSetpoint.getElevatorHeight().in(Meters),
+                                                CoralScorerSetpoint.PREALIGN
+                                                    .getElevatorHeight()
+                                                    .in(Meters))),
+                                    () -> CoralScorerSetpoint.PREALIGN.getArmAngle())
+                                .onlyWhile(
+                                    () ->
+                                        ReefAlign.isWithinReefRange(
+                                            drivetrain, ReefAlign.kMechanismDeadbandThreshold)))
+                        .until(drivetrain::atPoseSetpoint)
                         // we are aligned
                         .andThen(coralSuperstructure.goToSetpointProfiled(() -> queuedSetpoint))
                         .onlyWhile(
                             () ->
                                 ReefAlign.isWithinReefRange(
-                                    drivetrain, ReefAlign.kReefAlignmentThreshold)))
+                                    drivetrain, ReefAlign.kMechanismDeadbandThreshold)))
                 // and only do this while we're in the zone (when we're not, we will
                 // stay in the pre-alignment position)
                 .repeatedly());

--- a/src/main/java/frc/robot/auto/AutomaticAutonomousMaker3000.java
+++ b/src/main/java/frc/robot/auto/AutomaticAutonomousMaker3000.java
@@ -258,7 +258,7 @@ public class AutomaticAutonomousMaker3000 {
 
     return path.deadlineFor(
             coralSuperstructure
-                .goToSetpointProfiled(
+                .goToSetpointPID(
                     () -> CoralScorerSetpoint.NEUTRAL.getElevatorHeight(),
                     () -> CoralScorerSetpoint.NEUTRAL.getArmAngle())
                 .asProxy())
@@ -288,8 +288,14 @@ public class AutomaticAutonomousMaker3000 {
             ReefAlign.alignToReef(
                     drive, () -> pole == Pole.LEFTPOLE ? ReefPosition.LEFT : ReefPosition.RIGHT)
                 .asProxy()
-                .until(() -> drive.atPoseSetpoint())
+                .alongWith(
+                    coralSuperstructure.goToSetpointPID(
+                        () -> CoralScorerSetpoint.NEUTRAL.getElevatorHeight(),
+                        () -> ElevatorArmConstants.kPreAlignAngle))
+                .asProxy()
+                .until(() -> drive.atPoseSetpoint() && coralSuperstructure.atTargetState())
                 .andThen(coralSuperstructure.goToSetpointProfiled(() -> setpoint).asProxy())
+                .until(() -> coralSuperstructure.atTargetState())
                 .withTimeout(2.5))
         .andThen(
             ReefAlign.alignToReef(

--- a/src/main/java/frc/robot/auto/AutomaticAutonomousMaker3000.java
+++ b/src/main/java/frc/robot/auto/AutomaticAutonomousMaker3000.java
@@ -279,19 +279,12 @@ public class AutomaticAutonomousMaker3000 {
           case L4 -> CoralScorerSetpoint.L4;
         };
     return path.deadlineFor(
-            coralSuperstructure
-                .goToSetpointPID(
-                    () -> CoralScorerSetpoint.NEUTRAL.getElevatorHeight(),
-                    () -> ElevatorArmConstants.kPreAlignAngle)
-                .asProxy())
+            coralSuperstructure.goToSetpointPID(() -> CoralScorerSetpoint.PREALIGN).asProxy())
         .andThen(
             ReefAlign.alignToReef(
                     drive, () -> pole == Pole.LEFTPOLE ? ReefPosition.LEFT : ReefPosition.RIGHT)
                 .asProxy()
-                .alongWith(
-                    coralSuperstructure.goToSetpointPID(
-                        () -> CoralScorerSetpoint.NEUTRAL.getElevatorHeight(),
-                        () -> ElevatorArmConstants.kPreAlignAngle))
+                .alongWith(coralSuperstructure.goToSetpointPID(() -> CoralScorerSetpoint.PREALIGN))
                 .asProxy()
                 .until(() -> drive.atPoseSetpoint() && coralSuperstructure.atTargetState())
                 .andThen(coralSuperstructure.goToSetpointProfiled(() -> setpoint).asProxy())

--- a/src/main/java/frc/robot/auto/AutomaticAutonomousMaker3000.java
+++ b/src/main/java/frc/robot/auto/AutomaticAutonomousMaker3000.java
@@ -258,9 +258,9 @@ public class AutomaticAutonomousMaker3000 {
 
     return path.deadlineFor(
             coralSuperstructure
-                .goToSetpointPID(
+                .goToSetpointProfiled(
                     () -> CoralScorerSetpoint.NEUTRAL.getElevatorHeight(),
-                    () -> ElevatorArmConstants.kPreAlignAngle)
+                    () -> CoralScorerSetpoint.NEUTRAL.getArmAngle())
                 .asProxy())
         .andThen(
             pathCmd
@@ -288,8 +288,8 @@ public class AutomaticAutonomousMaker3000 {
             ReefAlign.alignToReef(
                     drive, () -> pole == Pole.LEFTPOLE ? ReefPosition.LEFT : ReefPosition.RIGHT)
                 .asProxy()
-                .alongWith(coralSuperstructure.goToSetpointProfiled(() -> setpoint).asProxy())
-                .until(() -> drive.atPoseSetpoint() && coralSuperstructure.atTargetState(setpoint))
+                .until(() -> drive.atPoseSetpoint())
+                .andThen(coralSuperstructure.goToSetpointProfiled(() -> setpoint).asProxy())
                 .withTimeout(2.5))
         .andThen(
             ReefAlign.alignToReef(

--- a/src/main/java/frc/robot/commands/ReefAlign.java
+++ b/src/main/java/frc/robot/commands/ReefAlign.java
@@ -10,6 +10,7 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
@@ -198,18 +199,21 @@ public class ReefAlign {
         .finallyDo(() -> Leds.getInstance().isReefAligning = false);
   }
 
-  public static Command alignToTag(
-      SwerveDrive swerveDrive, Supplier<ReefPosition> targetReefPosition) {
+  public static Command alignToTag(SwerveDrive swerveDrive) {
     return swerveDrive.driveToFieldPose(
         () -> {
           Pose2d target = getNearestReefPose(swerveDrive.getPose());
 
-          double distance =
-              swerveDrive.getPose().getTranslation().getDistance(target.getTranslation());
+          Translation2d translationError =
+              new Translation2d(
+                  swerveDrive.getPose().getTranslation().getDistance(target.getTranslation()),
+                  Rotation2d.kZero);
 
-          Pose2d newTarget = target.plus(new Transform2d(distance, 0, kReefAlignmentRotation));
+          Pose2d newTarget =
+              target.plus(new Transform2d(translationError.getX(), 0, kReefAlignmentRotation));
 
           swerveDrive.setAlignmentSetpoint(newTarget);
+
           return newTarget;
         });
   }

--- a/src/main/java/frc/robot/subsystems/CoralSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/CoralSuperstructure.java
@@ -124,7 +124,7 @@ public class CoralSuperstructure {
     L4(Meters.of(2.06).plus(Inches.of(1)), Degrees.of(85)),
     ALGAE_LOW(Meters.of(1), Degrees.of(40)), // TODO: actually tune
     ALGAE_HIGH(Meters.of(1.4), Degrees.of(40)), // TODO: actually tune
-    PREALIGN(ElevatorConstants.kElevatorStartingHeight.plus(Meters.of(0.3)), Degrees.of(150)),
+    PREALIGN(Inches.of(50), Degrees.of(150)),
     CLIMB(Meters.of(1.4), Degrees.of(0));
 
     private Distance elevatorHeight; // the height of the elevator to got

--- a/src/main/java/frc/robot/subsystems/CoralSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/CoralSuperstructure.java
@@ -124,7 +124,7 @@ public class CoralSuperstructure {
     L4(Meters.of(2.06).plus(Inches.of(1)), Degrees.of(85)),
     ALGAE_LOW(Meters.of(1), Degrees.of(40)), // TODO: actually tune
     ALGAE_HIGH(Meters.of(1.4), Degrees.of(40)), // TODO: actually tune
-    PREALIGN(Inches.of(50), Degrees.of(150)),
+    PREALIGN(Inches.of(40), Degrees.of(150)),
     CLIMB(Meters.of(1.4), Degrees.of(0));
 
     private Distance elevatorHeight; // the height of the elevator to got

--- a/src/main/java/frc/robot/subsystems/CoralSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/CoralSuperstructure.java
@@ -124,6 +124,7 @@ public class CoralSuperstructure {
     L4(Meters.of(2.06).plus(Inches.of(1)), Degrees.of(85)),
     ALGAE_LOW(Meters.of(1), Degrees.of(40)), // TODO: actually tune
     ALGAE_HIGH(Meters.of(1.4), Degrees.of(40)), // TODO: actually tune
+    PREALIGN(Inches.of(53), Degrees.of(150)),
     CLIMB(Meters.of(1.4), Degrees.of(0));
 
     private Distance elevatorHeight; // the height of the elevator to got

--- a/src/main/java/frc/robot/subsystems/CoralSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/CoralSuperstructure.java
@@ -124,7 +124,7 @@ public class CoralSuperstructure {
     L4(Meters.of(2.06).plus(Inches.of(1)), Degrees.of(85)),
     ALGAE_LOW(Meters.of(1), Degrees.of(40)), // TODO: actually tune
     ALGAE_HIGH(Meters.of(1.4), Degrees.of(40)), // TODO: actually tune
-    PREALIGN(Inches.of(53), Degrees.of(150)),
+    PREALIGN(ElevatorConstants.kElevatorStartingHeight.plus(Meters.of(0.3)), Degrees.of(150)),
     CLIMB(Meters.of(1.4), Degrees.of(0));
 
     private Distance elevatorHeight; // the height of the elevator to got

--- a/src/main/java/frc/robot/subsystems/CoralSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/CoralSuperstructure.java
@@ -14,7 +14,6 @@ import frc.robot.subsystems.coralendeffector.CoralEndEffectorConstants;
 import frc.robot.subsystems.elevator.Elevator;
 import frc.robot.subsystems.elevator.ElevatorConstants;
 import frc.robot.subsystems.elevatorarm.ElevatorArm;
-import frc.robot.subsystems.elevatorarm.ElevatorArmConstants;
 import frc.robot.util.TunableConstant;
 import java.util.function.Supplier;
 
@@ -102,7 +101,7 @@ public class CoralSuperstructure {
     TunableConstant armAngle = new TunableConstant("/CoralSuperstructure/ArmAngle", 0);
     TunableConstant height = new TunableConstant("/CoralSuperstructure/ElevatorHeight", 0);
 
-    return arm.goToAnglePID(() -> ElevatorArmConstants.kPreAlignAngle)
+    return arm.goToAnglePID(() -> CoralScorerSetpoint.PREALIGN.getArmAngle())
         .until(arm::atSetpoint)
         .andThen(elevator.goToHeight(() -> Meters.of(height.get())).until(elevator::atSetpoint))
         .andThen(arm.goToAnglePID(() -> Degrees.of(armAngle.get())));

--- a/src/main/java/frc/robot/subsystems/CoralSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/CoralSuperstructure.java
@@ -123,7 +123,7 @@ public class CoralSuperstructure {
     L4(Meters.of(2.06).plus(Inches.of(1)), Degrees.of(85)),
     ALGAE_LOW(Meters.of(1), Degrees.of(40)), // TODO: actually tune
     ALGAE_HIGH(Meters.of(1.4), Degrees.of(40)), // TODO: actually tune
-    PREALIGN(Inches.of(40), Degrees.of(150)),
+    PREALIGN(Inches.of(50), Degrees.of(150)),
     CLIMB(Meters.of(1.4), Degrees.of(0));
 
     private Distance elevatorHeight; // the height of the elevator to got

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainConstants.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainConstants.java
@@ -45,6 +45,6 @@ public class DrivetrainConstants {
 
   public static final Time kLoopDt = Seconds.of(0.02);
 
-  public static final Distance kAlignmentSetpointTranslationTolerance = Meters.of(0.015);
+  public static final Distance kAlignmentSetpointTranslationTolerance = Meters.of(0.05);
   public static final Angle kAlignmentSetpointRotationTolerance = Degrees.of(2.0);
 }

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
@@ -221,13 +221,6 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
 
     if (atPoseSetpoint()) targetSpeeds = new ChassisSpeeds();
 
-    // TODO: find better way
-    // if (Math.hypot(targetSpeeds.vxMetersPerSecond, targetSpeeds.vyMetersPerSecond) < 0.1)
-    //   targetSpeeds = new ChassisSpeeds(0, 0, targetSpeeds.omegaRadiansPerSecond);
-    // if (targetSpeeds.omegaRadiansPerSecond < 0.1)
-    //   targetSpeeds =
-    //       new ChassisSpeeds(targetSpeeds.vxMetersPerSecond, targetSpeeds.vyMetersPerSecond, 0);
-
     setControl(
         fieldCentricRequest
             .withDriveRequestType(DriveRequestType.Velocity)

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
@@ -3,9 +3,7 @@ package frc.robot.subsystems.drivetrain;
 
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Meters;
-import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.Radians;
-import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 
 import com.ctre.phoenix6.Utils;
@@ -38,7 +36,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.util.MyAlliance;
 import java.util.function.DoubleSupplier;
-import java.util.function.Supplier;
 
 /*
  * Real Drivetrain using CTRE SwerveDrivetrain and SwerveRequests
@@ -198,34 +195,18 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
   ;
 
   @Override
-  public Command driveToRobotPose(Supplier<Pose2d> pose) {
-    return runOnce(
-            () -> {
-              xPoseController.reset();
-              yPoseController.reset();
-              thetaController.reset();
-            })
-        .andThen(
-            run(
-                () -> {
-                  var targetSpeeds =
-                      ChassisSpeeds.discretize(
-                          xPoseController.calculate(getPose().getX(), pose.get().getX())
-                              * DrivetrainConstants.kMaxLinearVelocity.in(MetersPerSecond),
-                          yPoseController.calculate(getPose().getY(), pose.get().getY())
-                              * DrivetrainConstants.kMaxLinearVelocity.in(MetersPerSecond),
-                          thetaController.calculate(
-                                  getPose().getRotation().getRadians(),
-                                  pose.get().getRotation().getRadians())
-                              * DrivetrainConstants.kMaxAngularVelocity.in(RadiansPerSecond),
-                          DrivetrainConstants.kLoopDt.in(Seconds));
+  public void driveToRobotPose(Pose2d pose) {
+    ChassisSpeeds targetSpeeds =
+        ChassisSpeeds.discretize(
+            xPoseController.calculate(getPose().getX(), pose.getX()),
+            yPoseController.calculate(getPose().getY(), pose.getY()),
+            thetaController.calculate(
+                getPose().getRotation().getRadians(), pose.getRotation().getRadians()),
+            DrivetrainConstants.kLoopDt.in(Seconds));
 
-                  driveRobotCentric(
-                      targetSpeeds.vxMetersPerSecond,
-                      targetSpeeds.vyMetersPerSecond,
-                      targetSpeeds.omegaRadiansPerSecond,
-                      DriveFeedforwards.zeros(4));
-                }));
+    if (atPoseSetpoint()) targetSpeeds = new ChassisSpeeds();
+
+    setControl(robotCentricRequest.withSpeeds(targetSpeeds));
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
@@ -175,12 +175,6 @@ public class DrivetrainSim implements SwerveDrive {
 
     if (atPoseSetpoint()) targetSpeeds = new ChassisSpeeds();
 
-    // if (Math.hypot(targetSpeeds.vxMetersPerSecond, targetSpeeds.vyMetersPerSecond) < 0.1)
-    //   targetSpeeds = new ChassisSpeeds(0, 0, targetSpeeds.omegaRadiansPerSecond);
-    // if (targetSpeeds.omegaRadiansPerSecond < 0.1)
-    //   targetSpeeds =
-    //       new ChassisSpeeds(targetSpeeds.vxMetersPerSecond, targetSpeeds.vyMetersPerSecond, 0);
-
     simulatedDrive.runChassisSpeeds(targetSpeeds, Translation2d.kZero, false, false);
   }
 
@@ -196,12 +190,6 @@ public class DrivetrainSim implements SwerveDrive {
                 getPose().getRotation().getRadians(), pose.getRotation().getRadians()));
 
     if (atPoseSetpoint()) targetSpeeds = new ChassisSpeeds();
-
-    // if (Math.hypot(targetSpeeds.vxMetersPerSecond, targetSpeeds.vyMetersPerSecond) < 0.1)
-    //   targetSpeeds = new ChassisSpeeds(0, 0, targetSpeeds.omegaRadiansPerSecond);
-    // if (targetSpeeds.omegaRadiansPerSecond < 0.1)
-    //   targetSpeeds =
-    //       new ChassisSpeeds(targetSpeeds.vxMetersPerSecond, targetSpeeds.vyMetersPerSecond, 0);
 
     simulatedDrive.runChassisSpeeds(targetSpeeds, Translation2d.kZero, true, false);
   }

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
@@ -150,7 +150,18 @@ public interface SwerveDrive extends Subsystem {
   }
 
   // robot relative auto drive w/ external pid controllers
-  Command driveToRobotPose(Supplier<Pose2d> pose);
+  void driveToRobotPose(Pose2d pose);
+
+  default Command driveToRobotPose(Supplier<Pose2d> pose) {
+    return runOnce(
+            () -> {
+              xPoseController.reset();
+              yPoseController.reset();
+              thetaController.reset();
+              setAlignmentSetpoint(pose.get());
+            })
+        .andThen(run(() -> driveToRobotPose(pose.get())));
+  }
 
   // field relative auto drive w/ external pid controllers
   void driveToFieldPose(Pose2d pose);

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorConstants.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorConstants.java
@@ -31,6 +31,7 @@ public class ElevatorConstants {
   public static final Distance kElevatorMinimumHeight = Inches.of(35);
   public static final Distance kElevatorMaximumHeight = Inches.of(87.75);
   public static final Distance kElevatorStartingHeight = kElevatorMinimumHeight;
+  public static final Distance kPrealignHeight = Inches.of(53);
 
   public static final Distance kElevatorDangerHeight =
       Meters.of(0.9); // TODO: get this danger height

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorConstants.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorConstants.java
@@ -31,7 +31,6 @@ public class ElevatorConstants {
   public static final Distance kElevatorMinimumHeight = Inches.of(35);
   public static final Distance kElevatorMaximumHeight = Inches.of(87.75);
   public static final Distance kElevatorStartingHeight = kElevatorMinimumHeight;
-  public static final Distance kPrealignHeight = Inches.of(53);
 
   public static final Distance kElevatorDangerHeight =
       Meters.of(0.9); // TODO: get this danger height

--- a/src/main/java/frc/robot/subsystems/elevatorarm/ElevatorArmConstants.java
+++ b/src/main/java/frc/robot/subsystems/elevatorarm/ElevatorArmConstants.java
@@ -33,9 +33,6 @@ public class ElevatorArmConstants {
   // absolute encoder offset
   public static final Angle kAbsoluteEncoderOffset = Degrees.of(0);
 
-  // non-setpoint setpoints
-  public static final Angle kPreAlignAngle = Degrees.of(150);
-
   // controller config
   public static final Angle kAngleTolerance = Degrees.of(1);
 


### PR DESCRIPTION
# Description

Changed teleop alignment to pre-align superstructure while aligning and only scoring when the robot is aligned
Changed auto alignment to pre-align while pathing, and only scoring when robot is aligned 
Added `alignToTag()` which aligns the robot parallel with the tag to see tag for longer 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] In progress (fix or feature that isn't completed / ignore checklist if this is marked) 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] Someone have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules