### PR TITLE
[FIX] Added vision pose height filtering to remove the robot estimated pose jumps

### DIFF
--- a/src/main/java/frc/robot/subsystems/vision/Camera.java
+++ b/src/main/java/frc/robot/subsystems/vision/Camera.java
@@ -1,6 +1,8 @@
 /* (C) Robolancers 2025 */
 package frc.robot.subsystems.vision;
 
+import static edu.wpi.first.units.Units.Meters;
+
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.NotLogged;
 import edu.wpi.first.math.Matrix;
@@ -61,7 +63,11 @@ public class Camera {
         .filter(
             poseEst ->
                 VisionConstants.kAllowedFieldArea.contains(
-                    poseEst.estimatedPose.getTranslation().toTranslation2d()))
+                        poseEst.estimatedPose.getTranslation().toTranslation2d())
+                    && poseEst
+                        .estimatedPose
+                        .getMeasureZ()
+                        .isNear(Meters.zero(), VisionConstants.kAllowedFieldHeight))
         .map(
             photonEst -> {
               final var visionEst =

--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -139,6 +139,9 @@ public class VisionConstants {
   // camera data filtering
   public static final Distance kAllowedFieldDistance =
       Meters.of(2.5); // allow field estimates 2.5 meters outside field
+  public static final Distance kAllowedFieldHeight =
+      Meters.of(0.75); // Vision estimates can be at maximum 0.75 meters off the floor before being
+  // rejected
   public static final Rectangle2d kAllowedFieldArea =
       new Rectangle2d(
           new Translation2d(-kAllowedFieldDistance.in(Meters), -kAllowedFieldDistance.in(Meters)),


### PR DESCRIPTION
# Description

Mean pose error before (meters): 
![image](https://github.com/user-attachments/assets/9fb1ef1c-649c-4bc6-a2e9-47f6518678ee)

Mean pose error after (meters): 
![image](https://github.com/user-attachments/assets/51f060bf-c422-45a0-87c7-91b6b4f2b1a1)

Error for 1 camera looking at a single tag (meters; blue = old, gold = new):
![image](https://github.com/user-attachments/assets/c7e3b204-7cb3-410a-93b1-45cb52e648ab)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] In progress (fix or feature that isn't completed / ignore checklist if this is marked) 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] Someone have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules