### PR TITLE
[FIX] Made reef alignment only use the feed from the two reef cameras

### DIFF
--- a/src/main/java/frc/robot/commands/ReefAlign.java
+++ b/src/main/java/frc/robot/commands/ReefAlign.java
@@ -211,7 +211,8 @@ public class ReefAlign {
                       };
 
                   return new AlignmentSetpoint(target, true);
-                }))
+                },
+                swerveDrive::getReefVisionPose))
         .finallyDo(() -> Leds.getInstance().isReefAligning = false);
   }
 

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
@@ -197,26 +197,24 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
   }
 
   @Override
-  public void driveToFieldPose(Pose2d pose) {
+  public void driveToFieldPose(Pose2d pose, Pose2d currentPose) {
     ChassisSpeeds targetSpeeds =
         DriverStation.isAutonomous()
             ? ChassisSpeeds.discretize(
-                xPoseController.calculate(getPose().getX(), pose.getX())
+                xPoseController.calculate(currentPose.getX(), pose.getX())
                     + xPoseController.getSetpoint().velocity,
-                yPoseController.calculate(getPose().getY(), pose.getY())
+                yPoseController.calculate(currentPose.getY(), pose.getY())
                     + yPoseController.getSetpoint().velocity,
                 thetaController.calculate(
-                        getPose().getRotation().getRadians(), pose.getRotation().getRadians())
+                        currentPose.getRotation().getRadians(), pose.getRotation().getRadians())
                     + thetaController.getSetpoint().velocity,
                 RobotConstants.kRobotLoopPeriod.in(Seconds))
             : ChassisSpeeds.discretize(
-                xPoseController.calculate(getPose().getX(), pose.getX()),
-                yPoseController.calculate(getPose().getY(), pose.getY()),
+                xPoseController.calculate(currentPose.getX(), pose.getX()),
+                yPoseController.calculate(currentPose.getY(), pose.getY()),
                 thetaController.calculate(
-                    getPose().getRotation().getRadians(), pose.getRotation().getRadians()),
+                    currentPose.getRotation().getRadians(), pose.getRotation().getRadians()),
                 RobotConstants.kRobotLoopPeriod.in(Seconds));
-
-    final var currentPose = getPose();
 
     if (currentPose.getTranslation().getDistance(alignmentSetpoint.pose().getTranslation())
         < DrivetrainConstants.kAlignmentSetpointTranslationTolerance.in(Meters))

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
@@ -169,33 +169,30 @@ public class DrivetrainSim implements SwerveDrive {
   }
 
   @Override
-  public void driveToFieldPose(Pose2d pose) {
+  public void driveToFieldPose(Pose2d pose, Pose2d robotPose) {
     if (pose == null) return;
 
     ChassisSpeeds targetSpeeds =
         DriverStation.isAutonomous()
             ? new ChassisSpeeds(
-                xPoseController.calculate(getPose().getX(), pose.getX())
+                xPoseController.calculate(robotPose.getX(), pose.getX())
                     + xPoseController.getSetpoint().velocity,
-                yPoseController.calculate(getPose().getY(), pose.getY())
+                yPoseController.calculate(robotPose.getY(), pose.getY())
                     + yPoseController.getSetpoint().velocity,
                 thetaController.calculate(
-                        getPose().getRotation().getRadians(), pose.getRotation().getRadians())
+                        robotPose.getRotation().getRadians(), pose.getRotation().getRadians())
                     + thetaController.getSetpoint().velocity)
             : new ChassisSpeeds(
-                xPoseController.calculate(getPose().getX(), pose.getX()),
-                yPoseController.calculate(getPose().getY(), pose.getY()),
+                xPoseController.calculate(robotPose.getX(), pose.getX()),
+                yPoseController.calculate(robotPose.getY(), pose.getY()),
                 thetaController.calculate(
-                    getPose().getRotation().getRadians(), pose.getRotation().getRadians()));
+                    robotPose.getRotation().getRadians(), pose.getRotation().getRadians()));
 
-    final Pose2d currentPose = getPose();
-
-    if (currentPose.getTranslation().getDistance(alignmentSetpoint.pose().getTranslation())
+    if (robotPose.getTranslation().getDistance(alignmentSetpoint.pose().getTranslation())
         < DrivetrainConstants.kAlignmentSetpointTranslationTolerance.in(Meters))
       targetSpeeds = new ChassisSpeeds(0, 0, targetSpeeds.omegaRadiansPerSecond);
 
-    if (Math.abs(
-            currentPose.getRotation().minus(alignmentSetpoint.pose().getRotation()).getDegrees())
+    if (Math.abs(robotPose.getRotation().minus(alignmentSetpoint.pose().getRotation()).getDegrees())
         < DrivetrainConstants.kAlignmentSetpointRotationTolerance.in(Degrees))
       targetSpeeds =
           new ChassisSpeeds(targetSpeeds.vxMetersPerSecond, targetSpeeds.vyMetersPerSecond, 0);

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
@@ -166,9 +166,9 @@ public interface SwerveDrive extends Subsystem {
   }
 
   // field relative auto drive w/ external pid controllers
-  void driveToFieldPose(Pose2d pose);
+  void driveToFieldPose(Pose2d pose, Pose2d robotPose);
 
-  default Command driveToFieldPose(Supplier<AlignmentSetpoint> pose) {
+  default Command driveToFieldPose(Supplier<AlignmentSetpoint> pose, Supplier<Pose2d> robotPose) {
     return runOnce(
             () -> {
               ChassisSpeeds speeds =
@@ -186,8 +186,12 @@ public interface SwerveDrive extends Subsystem {
             run(
                 () -> {
                   setAlignmentSetpoint(pose.get());
-                  driveToFieldPose(pose.get().pose);
+                  driveToFieldPose(pose.get().pose, robotPose.get());
                 }));
+  }
+
+  default Command driveToFieldPose(Supplier<AlignmentSetpoint> pose) {
+    return driveToFieldPose(pose, this::getPose);
   }
 
   void resetPose(Pose2d pose);

--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -18,7 +18,7 @@ import org.photonvision.simulation.SimCameraProperties;
 
 public class VisionConstants {
   // TODO: tune more thoroughly
-  public static final double kTranslationStdDevCoeff = 1e-1;
+  public static final double kTranslationStdDevCoeff = 5e-2;
   public static final double kRotationStdDevCoeff = 1e-1;
 
   public static record CameraCalibration(


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] In progress (fix or feature that isn't completed / ignore checklist if this is marked) 

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] Someone have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules