### PR TITLE
[FEATURE] add 6328 transition between velo ff and PID values for alignment

### DIFF
--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainConstants.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainConstants.java
@@ -53,10 +53,9 @@ public class DrivetrainConstants {
 
   public static final Distance kAlignmentVelocityRadius =
       Meters.of(
-          0.1); // distance at which to start changing weights from velocity control to PID when
+          0.45); // distance at which to start changing weights from velocity control to PID when
   // aligning
   public static final Distance kAlignmentPIDRadius =
-      Meters.of(
-          0.03); // distance at which to end changing weights from velocity control to PID when
+      Meters.of(0.1); // distance at which to end changing weights from velocity control to PID when
   // aligning
 }

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainConstants.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainConstants.java
@@ -50,4 +50,13 @@ public class DrivetrainConstants {
 
   public static final Distance kAlignmentSetpointTranslationTolerance = Meters.of(0.01);
   public static final Angle kAlignmentSetpointRotationTolerance = Degrees.of(2.0);
+
+  public static final Distance kAlignmentVelocityRadius =
+      Meters.of(
+          0.1); // distance at which to start changing weights from velocity control to PID when
+  // aligning
+  public static final Distance kAlignmentPIDRadius =
+      Meters.of(
+          0.03); // distance at which to end changing weights from velocity control to PID when
+  // aligning
 }

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
@@ -205,16 +205,17 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
     double distance =
         currentPose.getTranslation().getDistance(alignmentSetpoint.pose().getTranslation());
 
-    double ffFactor =
-        DriverStation.isAutonomous()
-            ? (MathUtil.clamp(
-                        distance,
-                        DrivetrainConstants.kAlignmentPIDRadius.in(Meters),
-                        DrivetrainConstants.kAlignmentVelocityRadius.in(Meters))
-                    - DrivetrainConstants.kAlignmentPIDRadius.in(Meters))
-                / (DrivetrainConstants.kAlignmentVelocityRadius.in(Meters)
-                    - DrivetrainConstants.kAlignmentPIDRadius.in(Meters))
-            : 0;
+    // increase weighting of velocity from PID radius (weight = 0) to velocity radius (weight = 1)
+    double autoFfFactor =
+        (MathUtil.clamp(
+                    distance,
+                    DrivetrainConstants.kAlignmentPIDRadius.in(Meters),
+                    DrivetrainConstants.kAlignmentVelocityRadius.in(Meters))
+                - DrivetrainConstants.kAlignmentPIDRadius.in(Meters))
+            / (DrivetrainConstants.kAlignmentVelocityRadius.in(Meters)
+                - DrivetrainConstants.kAlignmentPIDRadius.in(Meters));
+
+    double ffFactor = DriverStation.isAutonomous() ? autoFfFactor : 0;
 
     ChassisSpeeds targetSpeeds =
         ChassisSpeeds.discretize(

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainReal.java
@@ -20,6 +20,7 @@ import com.ctre.phoenix6.swerve.SwerveRequest.ForwardPerspectiveValue;
 import com.pathplanner.lib.util.DriveFeedforwards;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.NotLogged;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -198,25 +199,33 @@ public class DrivetrainReal extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder>
 
   @Override
   public void driveToFieldPose(Pose2d pose) {
-    ChassisSpeeds targetSpeeds =
-        DriverStation.isAutonomous()
-            ? ChassisSpeeds.discretize(
-                xPoseController.calculate(getPose().getX(), pose.getX())
-                    + xPoseController.getSetpoint().velocity,
-                yPoseController.calculate(getPose().getY(), pose.getY())
-                    + yPoseController.getSetpoint().velocity,
-                thetaController.calculate(
-                        getPose().getRotation().getRadians(), pose.getRotation().getRadians())
-                    + thetaController.getSetpoint().velocity,
-                RobotConstants.kRobotLoopPeriod.in(Seconds))
-            : ChassisSpeeds.discretize(
-                xPoseController.calculate(getPose().getX(), pose.getX()),
-                yPoseController.calculate(getPose().getY(), pose.getY()),
-                thetaController.calculate(
-                    getPose().getRotation().getRadians(), pose.getRotation().getRadians()),
-                RobotConstants.kRobotLoopPeriod.in(Seconds));
 
     final var currentPose = getPose();
+
+    double distance =
+        currentPose.getTranslation().getDistance(alignmentSetpoint.pose().getTranslation());
+
+    double ffFactor =
+        DriverStation.isAutonomous()
+            ? (MathUtil.clamp(
+                        distance,
+                        DrivetrainConstants.kAlignmentPIDRadius.in(Meters),
+                        DrivetrainConstants.kAlignmentVelocityRadius.in(Meters))
+                    - DrivetrainConstants.kAlignmentPIDRadius.in(Meters))
+                / (DrivetrainConstants.kAlignmentVelocityRadius.in(Meters)
+                    - DrivetrainConstants.kAlignmentPIDRadius.in(Meters))
+            : 0;
+
+    ChassisSpeeds targetSpeeds =
+        ChassisSpeeds.discretize(
+            xPoseController.calculate(getPose().getX(), pose.getX())
+                + xPoseController.getSetpoint().velocity * ffFactor,
+            yPoseController.calculate(getPose().getY(), pose.getY())
+                + yPoseController.getSetpoint().velocity * ffFactor,
+            thetaController.calculate(
+                    getPose().getRotation().getRadians(), pose.getRotation().getRadians())
+                + thetaController.getSetpoint().velocity * ffFactor,
+            RobotConstants.kRobotLoopPeriod.in(Seconds));
 
     if (currentPose.getTranslation().getDistance(alignmentSetpoint.pose().getTranslation())
         < DrivetrainConstants.kAlignmentSetpointTranslationTolerance.in(Meters))

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
@@ -5,9 +5,11 @@ import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Pounds;
+import static edu.wpi.first.units.Units.Seconds;
 
 import com.pathplanner.lib.util.DriveFeedforwards;
 import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
@@ -26,6 +28,7 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.RobotConstants;
 import frc.robot.commands.ReefAlign;
 import frc.robot.util.SelfControlledSwerveDriveSimulationWrapper;
 import java.util.function.DoubleSupplier;
@@ -172,23 +175,32 @@ public class DrivetrainSim implements SwerveDrive {
   public void driveToFieldPose(Pose2d pose) {
     if (pose == null) return;
 
-    ChassisSpeeds targetSpeeds =
-        DriverStation.isAutonomous()
-            ? new ChassisSpeeds(
-                xPoseController.calculate(getPose().getX(), pose.getX())
-                    + xPoseController.getSetpoint().velocity,
-                yPoseController.calculate(getPose().getY(), pose.getY())
-                    + yPoseController.getSetpoint().velocity,
-                thetaController.calculate(
-                        getPose().getRotation().getRadians(), pose.getRotation().getRadians())
-                    + thetaController.getSetpoint().velocity)
-            : new ChassisSpeeds(
-                xPoseController.calculate(getPose().getX(), pose.getX()),
-                yPoseController.calculate(getPose().getY(), pose.getY()),
-                thetaController.calculate(
-                    getPose().getRotation().getRadians(), pose.getRotation().getRadians()));
-
     final Pose2d currentPose = getPose();
+
+    double distance =
+        currentPose.getTranslation().getDistance(alignmentSetpoint.pose().getTranslation());
+
+    double ffFactor =
+        DriverStation.isAutonomous()
+            ? (MathUtil.clamp(
+                        distance,
+                        DrivetrainConstants.kAlignmentPIDRadius.in(Meters),
+                        DrivetrainConstants.kAlignmentVelocityRadius.in(Meters))
+                    - DrivetrainConstants.kAlignmentPIDRadius.in(Meters))
+                / (DrivetrainConstants.kAlignmentVelocityRadius.in(Meters)
+                    - DrivetrainConstants.kAlignmentPIDRadius.in(Meters))
+            : 0;
+
+    ChassisSpeeds targetSpeeds =
+        ChassisSpeeds.discretize(
+            xPoseController.calculate(getPose().getX(), pose.getX())
+                + xPoseController.getSetpoint().velocity * ffFactor,
+            yPoseController.calculate(getPose().getY(), pose.getY())
+                + yPoseController.getSetpoint().velocity * ffFactor,
+            thetaController.calculate(
+                    getPose().getRotation().getRadians(), pose.getRotation().getRadians())
+                + thetaController.getSetpoint().velocity * ffFactor,
+            RobotConstants.kRobotLoopPeriod.in(Seconds));
 
     if (currentPose.getTranslation().getDistance(alignmentSetpoint.pose().getTranslation())
         < DrivetrainConstants.kAlignmentSetpointTranslationTolerance.in(Meters))

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSim.java
@@ -180,16 +180,17 @@ public class DrivetrainSim implements SwerveDrive {
     double distance =
         currentPose.getTranslation().getDistance(alignmentSetpoint.pose().getTranslation());
 
-    double ffFactor =
-        DriverStation.isAutonomous()
-            ? (MathUtil.clamp(
-                        distance,
-                        DrivetrainConstants.kAlignmentPIDRadius.in(Meters),
-                        DrivetrainConstants.kAlignmentVelocityRadius.in(Meters))
-                    - DrivetrainConstants.kAlignmentPIDRadius.in(Meters))
-                / (DrivetrainConstants.kAlignmentVelocityRadius.in(Meters)
-                    - DrivetrainConstants.kAlignmentPIDRadius.in(Meters))
-            : 0;
+    // increase weighting of velocity from PID radius (weight = 0) to velocity radius (weight = 1)
+    double autoFfFactor =
+        (MathUtil.clamp(
+                    distance,
+                    DrivetrainConstants.kAlignmentPIDRadius.in(Meters),
+                    DrivetrainConstants.kAlignmentVelocityRadius.in(Meters))
+                - DrivetrainConstants.kAlignmentPIDRadius.in(Meters))
+            / (DrivetrainConstants.kAlignmentVelocityRadius.in(Meters)
+                - DrivetrainConstants.kAlignmentPIDRadius.in(Meters));
+
+    double ffFactor = DriverStation.isAutonomous() ? autoFfFactor : 0;
 
     ChassisSpeeds targetSpeeds =
         ChassisSpeeds.discretize(


### PR DESCRIPTION


# Description

Add transition between velocity ff and pid values for the profiled pid controller to prevent crashing into reef when aligning during auto. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] In progress (fix or feature that isn't completed / ignore checklist if this is marked) 

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] Someone have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules