### PR TITLE
[FEATURE] Reimplement Vision with 6328 Guidance

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -8,6 +8,7 @@ import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.simulation.AddressableLEDSim;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -73,7 +74,8 @@ public class RobotContainer {
               drivetrain.addReefVisionMeasurement(
                   reefVisionEst.estimate().estimatedPose.toPose2d(),
                   reefVisionEst.estimate().timestampSeconds,
-                  reefVisionEst.stdDevs()));
+                  reefVisionEst.stdDevs()),
+          () -> new Rotation3d(drivetrain.getHeading()));
 
   private CommandXboxController driver = new CommandXboxController(0);
   private XboxController manipulator = new XboxController(1);

--- a/src/main/java/frc/robot/subsystems/vision/Camera.java
+++ b/src/main/java/frc/robot/subsystems/vision/Camera.java
@@ -1,17 +1,18 @@
 /* (C) Robolancers 2025 */
 package frc.robot.subsystems.vision;
 
-import static edu.wpi.first.units.Units.Meters;
-
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.NotLogged;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.wpilibj.Timer;
 import frc.robot.RobotConstants;
 import frc.robot.subsystems.vision.VisionConstants.CameraConfig;
+import java.util.function.Supplier;
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonCamera;
 import org.photonvision.PhotonPoseEstimator;
@@ -26,27 +27,41 @@ public class Camera {
 
   private final PhotonCamera camera;
 
-  private final PhotonPoseEstimator poseEstimator;
+  private final PhotonPoseEstimator multiTagEstimator;
+
+  private final PhotonPoseEstimator singleTagEstimator;
+
+  private Supplier<Rotation3d> heading;
 
   // for logging
   private VisionEstimate latestValidEstimate;
 
-  public Camera(CameraConfig config, PhotonCamera camera) {
+  public Camera(CameraConfig config, PhotonCamera camera, Supplier<Rotation3d> heading) {
     this.name = config.cameraName();
 
     this.usage = config.usage();
 
     this.camera = camera;
 
-    this.poseEstimator =
+    this.multiTagEstimator =
         new PhotonPoseEstimator(
             RobotConstants.kAprilTagFieldLayout,
             PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
             config.robotToCamera());
+
+    this.singleTagEstimator =
+        new PhotonPoseEstimator(
+            RobotConstants.kAprilTagFieldLayout,
+            PoseStrategy.PNP_DISTANCE_TRIG_SOLVE,
+            config.robotToCamera());
+
+    this.heading = heading;
   }
 
   @NotLogged
   public VisionEstimate tryLatestEstimate() {
+    singleTagEstimator.addHeadingData(Timer.getFPGATimestamp(), heading.get());
+
     if (!camera.isConnected()) return null;
 
     final var unreadResults = camera.getAllUnreadResults();
@@ -57,32 +72,69 @@ public class Camera {
 
     if (!latestResult.hasTargets()) return null;
 
-    final var estimate = poseEstimator.update(latestResult);
+    double poseAmbiguity = latestResult.getBestTarget().getPoseAmbiguity();
 
-    return estimate
-        .filter(
-            poseEst ->
-                VisionConstants.kAllowedFieldArea.contains(
-                        poseEst.estimatedPose.getTranslation().toTranslation2d())
-                    && poseEst
-                        .estimatedPose
-                        .getMeasureZ()
-                        .isNear(Meters.zero(), VisionConstants.kAllowedFieldHeight))
-        .map(
-            photonEst -> {
-              final var visionEst =
-                  new VisionEstimate(photonEst, calculateStdDevs(photonEst), name, usage);
-              latestValidEstimate = visionEst;
-              return visionEst;
-            })
-        .orElse(null);
+    final var multiTagEstimate =
+        multiTagEstimator
+            .update(latestResult)
+            .filter(
+                poseEst ->
+                    VisionConstants.kAllowedFieldArea.contains(
+                        poseEst.estimatedPose.getTranslation().toTranslation2d()))
+            .map(
+                photonEst -> {
+                  final var visionEst =
+                      new VisionEstimate(
+                          photonEst,
+                          calculateStdDevs(photonEst, EstimateType.MULTI_TAG, poseAmbiguity),
+                          name,
+                          usage,
+                          EstimateType.MULTI_TAG);
+
+                  return visionEst;
+                })
+            .orElse(null);
+
+    final var singleTagEstimate =
+        singleTagEstimator
+            .update(latestResult)
+            .filter(
+                poseEst ->
+                    VisionConstants.kAllowedFieldArea.contains(
+                        poseEst.estimatedPose.getTranslation().toTranslation2d()))
+            .map(
+                photonEst -> {
+                  final var visionEst =
+                      new VisionEstimate(
+                          photonEst,
+                          calculateStdDevs(photonEst, EstimateType.SINGLE_TAG, poseAmbiguity),
+                          name,
+                          usage,
+                          EstimateType.SINGLE_TAG);
+
+                  return visionEst;
+                })
+            .orElse(null);
+
+    return switch (latestResult.targets.size()) {
+      case 1 -> singleTagEstimate;
+      default -> multiTagEstimate;
+    };
   }
 
   // could be absolute nonsense, open to tuning constants for each robot camera config
   // assumes `result` has targets
   @NotLogged
-  private Matrix<N3, N1> calculateStdDevs(EstimatedRobotPose visionPoseEstimate) {
-    // weighted average by ambiguity
+  private Matrix<N3, N1> calculateStdDevs(
+      EstimatedRobotPose visionPoseEstimate, EstimateType estimateType, double poseAmbiguity) {
+    // weighted average by distance
+    if (poseAmbiguity > 0.4 && estimateType == EstimateType.SINGLE_TAG)
+      return VecBuilder.fill(
+          Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
+
+    double rotationStdDevMultiplier =
+        estimateType != EstimateType.SINGLE_TAG ? 1 : VisionConstants.kSingleTagStdDevCoeff;
+
     final double avgTargetDistance =
         visionPoseEstimate.targetsUsed.stream()
                 .mapToDouble(
@@ -103,6 +155,7 @@ public class Camera {
             / Math.pow(visionPoseEstimate.targetsUsed.size(), 3);
     final double rotationStdDev =
         VisionConstants.kRotationStdDevCoeff
+            * rotationStdDevMultiplier
             * Math.pow(avgTargetDistance, 3)
             / Math.pow(visionPoseEstimate.targetsUsed.size(), 3);
 

--- a/src/main/java/frc/robot/subsystems/vision/EstimateType.java
+++ b/src/main/java/frc/robot/subsystems/vision/EstimateType.java
@@ -1,0 +1,10 @@
+/* (C) Robolancers 2025 */
+package frc.robot.subsystems.vision;
+
+import edu.wpi.first.epilogue.Logged;
+
+@Logged
+public enum EstimateType {
+  SINGLE_TAG,
+  MULTI_TAG
+}

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -3,6 +3,7 @@ package frc.robot.subsystems.vision;
 
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.wpilibj.RobotBase;
 import frc.robot.util.VirtualSubsystem;
 import java.util.function.Consumer;
@@ -18,14 +19,16 @@ public class Vision extends VirtualSubsystem {
   public static Vision create(
       Supplier<Pose2d> robotPoseSupplier,
       Consumer<VisionEstimate> visionDataConsumer,
-      Consumer<VisionEstimate> reefVisionDataConsumer) {
+      Consumer<VisionEstimate> reefVisionDataConsumer,
+      Supplier<Rotation3d> robotHeadingSupplier) {
     return RobotBase.isReal()
         ? new Vision(
-            new VisionIOReal(VisionConstants.kCameraConfigs),
+            new VisionIOReal(robotHeadingSupplier, VisionConstants.kCameraConfigs),
             visionDataConsumer,
             reefVisionDataConsumer)
         : new Vision(
-            new VisionIOSim(robotPoseSupplier, VisionConstants.kCameraConfigs),
+            new VisionIOSim(
+                robotPoseSupplier, robotHeadingSupplier, VisionConstants.kCameraConfigs),
             visionDataConsumer,
             reefVisionDataConsumer);
   }

--- a/src/main/java/frc/robot/subsystems/vision/VisionEstimate.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionEstimate.java
@@ -15,4 +15,5 @@ public record VisionEstimate(
     EstimatedRobotPose estimate,
     Matrix<N3, N1> stdDevs,
     String sourceName,
-    CameraUsage sourceType) {}
+    CameraUsage sourceType,
+    EstimateType estimateType) {}

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOReal.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOReal.java
@@ -2,9 +2,11 @@
 package frc.robot.subsystems.vision;
 
 import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.math.geometry.Rotation3d;
 import frc.robot.subsystems.vision.VisionConstants.CameraConfig;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.photonvision.PhotonCamera;
 
@@ -12,10 +14,10 @@ import org.photonvision.PhotonCamera;
 public class VisionIOReal implements VisionIO {
   private final List<Camera> cameras;
 
-  public VisionIOReal(CameraConfig... configs) {
+  public VisionIOReal(Supplier<Rotation3d> headingSup, CameraConfig... configs) {
     cameras =
         Stream.of(configs)
-            .map(config -> new Camera(config, new PhotonCamera(config.cameraName())))
+            .map(config -> new Camera(config, new PhotonCamera(config.cameraName()), headingSup))
             .toList();
   }
 

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOSim.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOSim.java
@@ -4,6 +4,7 @@ package frc.robot.subsystems.vision;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.NotLogged;
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation3d;
 import frc.robot.RobotConstants;
 import frc.robot.subsystems.vision.VisionConstants.CameraConfig;
 import java.util.ArrayList;
@@ -26,7 +27,10 @@ public class VisionIOSim implements VisionIO {
 
   @NotLogged private final List<VisionTargetSim> targets;
 
-  public VisionIOSim(Supplier<Pose2d> robotPoseSupplier, CameraConfig... configs) {
+  public VisionIOSim(
+      Supplier<Pose2d> robotPoseSupplier,
+      Supplier<Rotation3d> headingSup,
+      CameraConfig... configs) {
     this.sim = new VisionSystemSim("main");
     sim.addAprilTags(RobotConstants.kAprilTagFieldLayout);
 
@@ -37,7 +41,7 @@ public class VisionIOSim implements VisionIO {
                   final var camera = new PhotonCamera(config.cameraName());
                   final var cameraSim = new PhotonCameraSim(camera, config.calib().simProperties());
                   sim.addCamera(cameraSim, config.robotToCamera());
-                  return new Camera(config, camera);
+                  return new Camera(config, camera, headingSup);
                 })
             .toList();
 


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

> New vision pipeline:
> 
> multiple tag -> update pose est with those tags (trans + rotate)
> 
> Low rotation std devs
> Single tag + >0.4 ambig -> reject
> 
> Single tag + <0.4 ambig -> disambiguate (use a separate trig solve photon pose estimator for this), high rotation std devs
> 
> use rotation component of the main pose estimate for trig solve angles

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] Someone have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules