### PR TITLE
[FIX] Reverted scoring speeds to allow for L2 and L3 scoring, removed requirement for intaking to be in coral mode

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -356,7 +356,7 @@ public class RobotContainer {
     // RIGHT BUMPER + CORAL MODE = INTAKE CORAL
     driver
         .rightBumper()
-        .and(isHighCoralSetpoint.or(isL1Setpoint))
+        // .and(isHighCoralSetpoint.or(isL1Setpoint))
         .whileTrue(
             StationAlign.rotateToNearestStationTag(drivetrain, driverForward, driverStrafe)
                 .onlyWhile(() -> StationAlign.getStationDistance(drivetrain) < 2)

--- a/src/main/java/frc/robot/subsystems/coralendeffector/CoralEndEffectorConstants.java
+++ b/src/main/java/frc/robot/subsystems/coralendeffector/CoralEndEffectorConstants.java
@@ -22,8 +22,8 @@ public class CoralEndEffectorConstants {
   // Setpoints
   public static final AngularVelocity kCoralIntakeRPM = RPM.of(3000);
   public static final AngularVelocity kL1OuttakeRPM = RPM.of(-3142);
-  public static final AngularVelocity kL2OuttakeRPM = RPM.of(-1000);
-  public static final AngularVelocity kL3OuttakeRPM = RPM.of(-1000);
+  public static final AngularVelocity kL2OuttakeRPM = RPM.of(-1500);
+  public static final AngularVelocity kL3OuttakeRPM = RPM.of(-1500);
   public static final AngularVelocity kL4OuttakeRPM = RPM.of(-1500);
   public static final AngularVelocity kCoralStallRPM = RPM.of(500);
   public static final AngularVelocity kAlgaeKnockRPM = RPM.of(-3000);


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] In progress (fix or feature that isn't completed / ignore checklist if this is marked) 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] Someone have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules